### PR TITLE
Tiny spelling fix in answer about salary more than $200k

### DIFF
--- a/src/i18n/en-US/common.yml
+++ b/src/i18n/en-US/common.yml
@@ -319,7 +319,7 @@ translations:
     - key: options.yearly_salary.range_100_200
       t: $100k-$200k
     - key: options.yearly_salary.range_more_than_200
-      t: more than $200k
+      t: More than $200k
 
     # salary (short versions)
     - key: options.yearly_salary.range_work_for_free.short

--- a/src/i18n/es-ES/common.yml
+++ b/src/i18n/es-ES/common.yml
@@ -313,7 +313,7 @@ translations:
   - key: options.yearly_salary.range_100_200
     t: $100k-$200k
   - key: options.yearly_salary.range_more_than_200
-    t: más de $200k
+    t: Más de $200k
 
   # salary (short versions)
   - key: options.yearly_salary.range_work_for_free.short

--- a/src/i18n/fr-FR/common.yml
+++ b/src/i18n/fr-FR/common.yml
@@ -315,7 +315,7 @@ translations:
     - key: options.yearly_salary.range_100_200
       t: $100k - $200k
     - key: options.yearly_salary.range_more_than_200
-      t: plus de $200k
+      t: Plus de $200k
 
     # salary (short versions)
     - key: options.yearly_salary.range_work_for_free.short

--- a/src/i18n/model/common.yml
+++ b/src/i18n/model/common.yml
@@ -315,7 +315,7 @@ translations:
     - key: options.yearly_salary.range_100_200 # TODO
       t: $100k-$200k
     - key: options.yearly_salary.range_more_than_200 # TODO
-      t: more than $200k
+      t: More than $200k
 
     # salary (short versions)
     - key: options.yearly_salary.range_work_for_free.short # TODO

--- a/src/i18n/pt-PT/common.yml
+++ b/src/i18n/pt-PT/common.yml
@@ -315,7 +315,7 @@ translations:
     - key: options.yearly_salary.range_100_200
       t: $100k-$200k
     - key: options.yearly_salary.range_more_than_200
-      t: mais de $200k
+      t: Mais de $200k
 
     # salary (short versions)
     - key: options.yearly_salary.range_work_for_free.short


### PR DESCRIPTION
To achieve consistency in answers that usually start with a capital letter.