### PR TITLE
Fix names in russian translation of state_of_css_2020

### DIFF
--- a/src/i18n/ru-RU/state_of_css_2020.yml
+++ b/src/i18n/ru-RU/state_of_css_2020.yml
@@ -33,7 +33,7 @@ translations:
 
             ### Благодарности
 
-            Спасибо всем, кто помог нам сделать этот опрос, особенно [Чену Хуй-Цзину (Chen Hui-Jing)](http://chenhuijing.com/), [Филипу Ягенштедту (Philip Jägenstedt)](https://blog.foolip.org/), [Адаму Аргайку (Adam Argyke)](https://nerdy.dev/), [Ахмаду Шадиду (Ahmad Shadeed)](https://www.ishadeed.com/), [Роберту Флэку (Robert Flack)](https://github.com/flackr), [Доминику Нгуену (Dominic Nguyen)](https://www.chromatic.com/), [Фантазаю (Fantasai)](http://fantasai.inkedblade.net/) и [Килиану Валкхофу (Kilian Valkhof)](https://kilianvalkhof.com/).
+            Спасибо всем, кто помог нам сделать этот опрос, особенно [Чэнь Хуэй Цзин (Chen Hui-Jing)](http://chenhuijing.com/), [Филипу Ягенштедту (Philip Jägenstedt)](https://blog.foolip.org/), [Адаму Аргайлу (Adam Argyle)](https://nerdy.dev/), [Ахмаду Шадиду (Ahmad Shadeed)](https://www.ishadeed.com/), [Роберту Флэку (Robert Flack)](https://github.com/flackr), [Доминику Нгуену (Dominic Nguyen)](https://www.chromatic.com/), [Элике Фантазай (Fantasai)](http://fantasai.inkedblade.net/) и [Килиану Валкхофу (Kilian Valkhof)](https://kilianvalkhof.com/).
 
             Отдельная благодарность [Алексею Пыльцыну (Alexey Pyltsyn)](https://github.com/lex111) за помощь над переводами.
 


### PR DESCRIPTION
HJ Chen is she, not he. There is approved by Chen Russian translation: https://github.com/web-standards-ru/dictionary/blob/master/names.md#h

Adam Argy**l**e, not Argy**k**e.

Fantasai is she.