### PR TITLE
intl(ua): add links to ukrainian translate from other languages

### DIFF
--- a/src/i18n/de-DE/results.yml
+++ b/src/i18n/de-DE/results.yml
@@ -113,6 +113,8 @@ translations:
       t: Spanisch
     - key: options.locale.ru-RU
       t: Russisch
+    - key: options.locale.ua-UA
+      t: Oekraïens
     - key: options.locale.fr-FR
       t: Französisch
     - key: options.locale.zh-Hant

--- a/src/i18n/en-US/results.yml
+++ b/src/i18n/en-US/results.yml
@@ -127,6 +127,8 @@ translations:
       t: Spanish
     - key: options.locale.ru-RU
       t: Russian
+    - key: options.locale.ua-UA
+      t: Ukrainian
     - key: options.locale.fr-FR
       t: French
     - key: options.locale.zh-Hant

--- a/src/i18n/es-ES/results.yml
+++ b/src/i18n/es-ES/results.yml
@@ -113,6 +113,8 @@ translations:
       t: Español
     - key: options.locale.ru-RU
       t: Ruso
+    - key: options.locale.ua-UA
+      t: Ucranio
     - key: options.locale.fr-FR
       t: Francés
     - key: options.locale.zh-Hant

--- a/src/i18n/tr-TR/results.yml
+++ b/src/i18n/tr-TR/results.yml
@@ -114,7 +114,7 @@ translations:
     - key: options.locale.ru-RU
       t: Rusça
     - key: options.locale.ua-UA
-      t: Ukrainian
+      t: Ukrayna
     - key: options.locale.fr-FR
       t: Fransızca
     - key: options.locale.zh-Hant

--- a/src/i18n/tr-TR/results.yml
+++ b/src/i18n/tr-TR/results.yml
@@ -113,6 +113,8 @@ translations:
       t: İspanyolca
     - key: options.locale.ru-RU
       t: Rusça
+    - key: options.locale.ua-UA
+      t: Ukrainian
     - key: options.locale.fr-FR
       t: Fransızca
     - key: options.locale.zh-Hant

--- a/src/i18n/zh-Hant/results.yml
+++ b/src/i18n/zh-Hant/results.yml
@@ -124,6 +124,8 @@ translations:
       t: Spanish
     - key: options.locale.ru-RU
       t: Russian
+    - key: options.locale.ua-UA
+      t: Ukrainian
     - key: options.locale.fr-FR
       t: French
     - key: options.locale.zh-Hant


### PR DESCRIPTION
@SachaG
Hey. I added, by analogy with Russian, links to Ukrainian from other translations, do I need to do something else for the Ukrainian translation to appear?