### PR TITLE
add Japanese translation for State of CSS

### DIFF
--- a/src/i18n/ja-JP/state_of_css.yml
+++ b/src/i18n/ja-JP/state_of_css.yml
@@ -16,8 +16,19 @@ translations:
           So after the success of our annual State Of JavaScript survey,
           we’ve decided to take on the world of styles and selectors. We're hoping you’ll help
           us identify the latest trends, and figure out what tools to learn and use next!
+      t: >
+          CSS is evolving faster than ever.
+
+
+          Flexbox, Grid, Multi-Column… To say nothing of whole new paradigms like CSS-in-JS.
+
+
+          So after the success of our annual State Of JavaScript survey,
+          we’ve decided to take on the world of styles and selectors. We're hoping you’ll help
+          us identify the latest trends, and figure out what tools to learn and use next!
 
     - key: general.results.description
+      t: The annual survey about the latest trends in CSS.
       t: The annual survey about the latest trends in CSS.
 
     ###########################################################################
@@ -26,89 +37,123 @@ translations:
 
     - key: sections.layout.title
       t: Layout
+      t: Layout
     - key: sections.layout.description
+      t: How do you position elements on the screen?
       t: How do you position elements on the screen?
 
     - key: sections.shapes_graphics.title
       t: Shapes & Graphics
+      t: Shapes & Graphics
     - key: sections.shapes_graphics.description
+      t: Controlling the shape and display of elements.
       t: Controlling the shape and display of elements.
 
     - key: sections.interactions.title
       t: Interactions
+      t: Interactions
     - key: sections.interactions.description
+      t: Controlling how the user interacts with the page.
       t: Controlling how the user interacts with the page.
 
     - key: sections.typography.title
       t: Typography
+      t: Typography
     - key: sections.typography.description
+      t: Setting and laying out text.
       t: Setting and laying out text.
 
     - key: sections.animations_transforms.title
       t: Animations & Transforms
+      t: Animations & Transforms
     - key: sections.animations_transforms.description
+      t: Animating and transforming elements.
       t: Animating and transforming elements.
 
     - key: sections.media_queries.title
       t: Media Queries
+      t: Media Queries
     - key: sections.media_queries.description
+      t: Ways of adapting your site to the user's device or preferences.
       t: Ways of adapting your site to the user's device or preferences.
 
     - key: sections.other_features.title
       t: Other Features
+      t: Other Features
     - key: sections.other_features.description
+      t: Other CSS features.
       t: Other CSS features.
 
     - key: sections.units_selectors.title
       t: Units & Selectors
+      t: Units & Selectors
     - key: sections.units_selectors.description
+      t: Test your knowledge of CSS units and selectors.
       t: Test your knowledge of CSS units and selectors.
 
     - key: sections.pre_post_processors.title
       t: Pre-/Post-processors
+      t: Pre-/Post-processors
     - key: sections.pre_post_processors.description
+      t: Utilities that augment CSS.
       t: Utilities that augment CSS.
 
     - key: sections.pre_post_processors_others.title
       t: Other Pre-/Post-processors
+      t: Other Pre-/Post-processors
 
     - key: sections.css_frameworks.title
       t: CSS Frameworks
+      t: CSS Frameworks
     - key: sections.css_frameworks.description
+      t: Libraries that give you pre-made components and styles.
       t: Libraries that give you pre-made components and styles.
 
     - key: sections.css_frameworks_others.title
       t: Other CSS Frameworks
+      t: Other CSS Frameworks
 
     - key: sections.css_methodologies.title
       t: CSS Methodologies
+      t: CSS Methodologies
     - key: sections.css_methodologies.description
+      t: Codified ways to write cleaner CSS.
       t: Codified ways to write cleaner CSS.
 
     - key: sections.css_methodologies_others.title
       t: Other CSS Methodologies.
+      t: Other CSS Methodologies.
 
     - key: sections.css_in_js.title
       t: CSS-in-JS
+      t: CSS-in-JS
     - key: sections.css_in_js.description
+      t: Libraries that help integrate CSS into JavaScript code.
       t: Libraries that help integrate CSS into JavaScript code.
 
     - key: sections.css_in_js_others.title
       t: Other CSS-in-JS Libraries.
+      t: Other CSS-in-JS Libraries.
 
     - key: sections.tools_others.title
       t: Other Tools
+      t: Other Tools
     - key: sections.tools_others.description
+      t: Other CSS tools.
       t: Other CSS tools.
 
     - key: sections.environments.title
       t: Environments
+      t: Environments
     - key: sections.environments.description
+      t: Which environments do you write CSS for?
       t: Which environments do you write CSS for?
 
     - key: sections.awards.title
       t: Awards
+      t: Awards
     - key: sections.awards.description
+      t: Things that stood out this year.
       t: Things that stood out this year.
 
     ###########################################################################
@@ -118,43 +163,59 @@ translations:
     # CSS for print
     - key: options.css_for_print.0
       t: I (almost) never write print styles
+      t: I (almost) never write print styles
     - key: options.css_for_print.0.short
+      t: Never
       t: Never
 
     - key: options.css_for_print.1
       t: I occasionally write print styles
+      t: I occasionally write print styles
     - key: options.css_for_print.1.short
+      t: Occasionally
       t: Occasionally
 
     - key: options.css_for_print.2
       t: I write print styles as part of most projects
+      t: I write print styles as part of most projects
     - key: options.css_for_print.2.short
+      t: Often
       t: Often
 
     - key: options.css_for_print.3
       t: I focus mainly on CSS for print
+      t: I focus mainly on CSS for print
     - key: options.css_for_print.3.short
+      t: Mainly
       t: Mainly
 
     # CSS for email
     - key: options.css_for_email.0
       t: I (almost) never write CSS for email clients
+      t: I (almost) never write CSS for email clients
     - key: options.css_for_email.0.short
+      t: Never
       t: Never
 
     - key: options.css_for_email.1
       t: I occasionally write CSS for email clients
+      t: I occasionally write CSS for email clients
     - key: options.css_for_email.1.short
+      t: Occasionally
       t: Occasionally
 
     - key: options.css_for_email.2
       t: I write CSS for email clients as part of most projects
+      t: I write CSS for email clients as part of most projects
     - key: options.css_for_email.2.short
+      t: Often
       t: Often
 
     - key: options.css_for_email.3
       t: I focus mainly on CSS for email clients
+      t: I focus mainly on CSS for email clients
     - key: options.css_for_email.3.short
+      t: Mainly
       t: Mainly
 
     ###########################################################################
@@ -283,7 +344,9 @@ translations:
     # knowledge score
     - key: features.knowledge_score
       t: Knowledge Score
+      t: Knowledge Score
     - key: features.knowledge_score.description
+      t: Out of all the CSS features mentioned in the survey, how many did the respondent know about?
       t: Out of all the CSS features mentioned in the survey, how many did the respondent know about?
       
     ###########################################################################
@@ -292,7 +355,9 @@ translations:
 
     - key: features_others.units
       t: Units
+      t: Units
     - key: features_others.units.description
+      t: Which of these CSS units have you used?
       t: Which of these CSS units have you used?
 
     - key: options.units.px
@@ -322,7 +387,9 @@ translations:
 
     - key: features_others.pseudo_elements
       t: Pseudo Elements
+      t: Pseudo Elements
     - key: features_others.pseudo_elements.description
+      t: Which of these CSS pseudo-elements have you used?
       t: Which of these CSS pseudo-elements have you used?
 
     - key: options.pseudo_elements.before
@@ -344,21 +411,29 @@ translations:
 
     - key: features_others.combinators
       t: Combinators
+      t: Combinators
     - key: features_others.combinators.description
+      t: Which of these combinations CSS selectors have you used?
       t: Which of these combinations CSS selectors have you used?
 
     - key: options.combinators.descendant
       t: div span (descendant)
+      t: div span (descendant)
     - key: options.combinators.child
+      t: div > span (child)
       t: div > span (child)
     - key: options.combinators.next_sibling
       t: div + div (next sibling)
+      t: div + div (next sibling)
     - key: options.combinators.subsequent_sibling
+      t: div ~ div (subsequent sibling)
       t: div ~ div (subsequent sibling)
 
     - key: features_others.tree_document_structure
       t: Tree / Document Structure
+      t: Tree / Document Structure
     - key: features_others.tree_document_structure.description
+      t: Which of these structure related CSS selectors have you used?
       t: Which of these structure related CSS selectors have you used?
 
     - key: options.tree_document_structure.root
@@ -398,25 +473,35 @@ translations:
 
     - key: features_others.attributes
       t: Attributes
+      t: Attributes
     - key: features_others.attributes.description
+      t: Which of these CSS attributes selectors have you used?
       t: Which of these CSS attributes selectors have you used?
 
     - key: options.attributes.presence
       t: div[foo] (Presence)
+      t: div[foo] (Presence)
     - key: options.attributes.equality
+      t: div[foo="bar"] (Equality)
       t: div[foo="bar"] (Equality)
     - key: options.attributes.starts_with
       t: div[foo^="bar"] (Starts with)
+      t: div[foo^="bar"] (Starts with)
     - key: options.attributes.ends_with
+      t: div[foo$="bar"] (Ends with)
       t: div[foo$="bar"] (Ends with)
     - key: options.attributes.contains_word
       t: div[foo~="bar"] (Contains word)
+      t: div[foo~="bar"] (Contains word)
     - key: options.attributes.contains_substring
+      t: div[foo*="bar"] (Contains substring)
       t: div[foo*="bar"] (Contains substring)
 
     - key: features_others.links_urls
       t: Links/URLs
+      t: Links/URLs
     - key: features_others.links_urls.description
+      t: Which of these links & URLs related CSS selectors have you used?
       t: Which of these links & URLs related CSS selectors have you used?
 
     - key: options.links_urls.any_link
@@ -430,7 +515,9 @@ translations:
 
     - key: features_others.interaction
       t: Interaction
+      t: Interaction
     - key: features_others.interaction.description
+      t: Which of these interaction CSS selectors have you used?
       t: Which of these interaction CSS selectors have you used?
 
     - key: options.interaction.hover
@@ -446,7 +533,9 @@ translations:
 
     - key: features_others.form_controls
       t: Form Controls
+      t: Form Controls
     - key: features_others.form_controls.description
+      t: Which of these form related CSS selectors have you used?
       t: Which of these form related CSS selectors have you used?
 
     - key: options.form_controls.enabled_disabled
@@ -476,27 +565,37 @@ translations:
 
     - key: environments.browsers
       t: Browsers
+      t: Browsers
     - key: environments.browsers.description
+      t: Which browsers do you test in?
       t: Which browsers do you test in?
 
     - key: environments.form_factors
       t: Form Factors
+      t: Form Factors
     - key: environments.form_factors.description
+      t: Which form factors do you test on?
       t: Which form factors do you test on?
 
     - key: environments.css_for_print
       t: CSS for Print
+      t: CSS for Print
     - key: environments.css_for_print.description
+      t: Do you write print styles?
       t: Do you write print styles?
 
     - key: environments.css_for_email
       t: CSS for Email Clients
+      t: CSS for Email Clients
     - key: environments.css_for_email.description
+      t: Do you write CSS for email clients?
       t: Do you write CSS for email clients?
 
     - key: charts.axis_legends.css_for_print
       t: Frequency
+      t: Frequency
     - key: charts.axis_legends.css_for_email
+      t: Frequency
       t: Frequency
 
     ###########################################################################
@@ -505,37 +604,51 @@ translations:
 
     - key: opinions.css_easy_to_learn
       t: CSS is easy to learn
+      t: CSS is easy to learn
     - key: opinions.css_easy_to_learn.title
+      t: Learning Curve
       t: Learning Curve
 
     - key: opinions.css_evolving_slowly
       t: CSS is evolving too slowly
+      t: CSS is evolving too slowly
     - key: opinions.css_evolving_slowly.title
+      t: Rate of Change
       t: Rate of Change
 
     - key: opinions.utility_classes_to_be_avoided
       t: Utility (non-semantic) classes (.center, .large-text, etc.) should be avoided
+      t: Utility (non-semantic) classes (.center, .large-text, etc.) should be avoided
     - key: opinions.utility_classes_to_be_avoided.title
+      t: Non-Semantic Classes
       t: Non-Semantic Classes
 
     - key: opinions.selector_nesting_to_be_avoided
       t: Selector nesting (.foo .bar ul li {...}) should be avoided
+      t: Selector nesting (.foo .bar ul li {...}) should be avoided
     - key: opinions.selector_nesting_to_be_avoided.title
+      t: Selector Nesting
       t: Selector Nesting
 
     - key: opinions.css_is_programming_language
       t: CSS is a programming language
+      t: CSS is a programming language
     - key: opinions.css_is_programming_language.title
+      t: Programming Language
       t: Programming Language
 
     - key: opinions.enjoy_writing_css
       t: I enjoy writing CSS
+      t: I enjoy writing CSS
     - key: opinions.enjoy_writing_css.title
+      t: Enjoyment
       t: Enjoyment
 
     - key: opinions_others.currently_missing_from_css.others
       t: What do you feel is currently missing from CSS?
+      t: What do you feel is currently missing from CSS?
     - key: opinions_others.currently_missing_from_css.others.description
+      t: Features you'd like to see in CSS one day.
       t: Features you'd like to see in CSS one day.
     - key: opinions_others.currently_missing_from_css.others.note
       t: >
@@ -544,11 +657,15 @@ translations:
     
     - key: opinions.sum_up_one_word_css
       t: CSS in one word
+      t: CSS in one word
     - key: opinions.sum_up_one_word_css.description
+      t: How would you sum up your opinion of CSS in one word?
       t: How would you sum up your opinion of CSS in one word?
 
     - key: happiness.state_of_the_web
       t: How happy are you with the general state of web technologies?
+      t: How happy are you with the general state of web technologies?
 
     - key: happiness.state_of_css
+      t: How happy are you with the general state of CSS?
       t: How happy are you with the general state of CSS?

--- a/src/i18n/ja-JP/state_of_css.yml
+++ b/src/i18n/ja-JP/state_of_css.yml
@@ -40,17 +40,17 @@ translations:
 
     - key: sections.shapes_graphics.title
       t: Shapes & Graphics
-      t: 形状とグラフィクス
+      t: シェイプ＆グラフィクス
     - key: sections.shapes_graphics.description
       t: Controlling the shape and display of elements.
-      t: 要素の形状と表示を制御する。
+      t: 要素の形と表示を制御する。
 
     - key: sections.interactions.title
       t: Interactions
       t: インタラクション
     - key: sections.interactions.description
       t: Controlling how the user interacts with the page.
-      t: ユーザーがどのようにページに触れるかを制御する。
+      t: ユーザーとページのインタラクションを調整する。
 
     - key: sections.typography.title
       t: Typography
@@ -64,21 +64,21 @@ translations:
       t: アニメーション＆トランスフォーム
     - key: sections.animations_transforms.description
       t: Animating and transforming elements.
-      t: 要素をアニメーションさせたり、変形させたりします。
+      t: 要素のアニメーションや変形。
 
     - key: sections.media_queries.title
       t: Media Queries
       t: メディアクエリー
     - key: sections.media_queries.description
       t: Ways of adapting your site to the user's device or preferences.
-      t: ユーザーのデバイスや設定に沿うようサイトを調整します。
+      t: デバイスやユーザーの設定にあわせる。
 
     - key: sections.other_features.title
       t: Other Features
       t: そのほかの機能
     - key: sections.other_features.description
       t: Other CSS features.
-      t: そのほかのCSSの機能
+      t: そのほかのCSSの機能。
 
     - key: sections.units_selectors.title
       t: Units & Selectors
@@ -103,7 +103,7 @@ translations:
       t: CSSフレームワーク
     - key: sections.css_frameworks.description
       t: Libraries that give you pre-made components and styles.
-      t: 定義済みのコンポーネントとそのスタイルを提供するライブラリ。
+      t: コンポーネントとスタイルを提供するライブラリ。
 
     - key: sections.css_frameworks_others.title
       t: Other CSS Frameworks
@@ -114,7 +114,7 @@ translations:
       t: CSS設計手法
     - key: sections.css_methodologies.description
       t: Codified ways to write cleaner CSS.
-      t: きれいなCSSを書くためのcodified手法。
+      t: きれいなCSSを書くために体系化された手法。
 
     - key: sections.css_methodologies_others.title
       t: Other CSS Methodologies.
@@ -140,7 +140,7 @@ translations:
 
     - key: sections.environments.title
       t: Environments
-      t: Environments
+      t: 対応環境
     - key: sections.environments.description
       t: Which environments do you write CSS for?
       t: どんな環境に向けてCSSを書いているか。
@@ -180,7 +180,7 @@ translations:
 
     - key: options.css_for_print.3
       t: I focus mainly on CSS for print
-      t: CSSは印刷用スタイルだけ書いている
+      t: CSSは印刷用スタイルを主に書いている
     - key: options.css_for_print.3.short
       t: Mainly
       t: 専業
@@ -209,7 +209,7 @@ translations:
 
     - key: options.css_for_email.3
       t: I focus mainly on CSS for email clients
-      t: メール用のCSSだけ書いている
+      t: メール用のCSSを主に書いている
     - key: options.css_for_email.3.short
       t: Mainly
       t: 専業
@@ -642,7 +642,7 @@ translations:
 
     - key: opinions_others.currently_missing_from_css.others
       t: What do you feel is currently missing from CSS?
-      t: CSSにいま足りないものは何だと思っているか。
+      t: CSSにいま足りないものは何か。
     - key: opinions_others.currently_missing_from_css.others.description
       t: Features you'd like to see in CSS one day.
       t: CSSにいつかほしい機能。
@@ -658,7 +658,7 @@ translations:
       t: CSSを一言で言うと
     - key: opinions.sum_up_one_word_css.description
       t: How would you sum up your opinion of CSS in one word?
-      t: CSSについて何か一言で意見を言うなら。
+      t: CSSについて何かひとこと言うなら。
 
     - key: happiness.state_of_the_web
       t: How happy are you with the general state of web technologies?

--- a/src/i18n/ja-JP/state_of_css.yml
+++ b/src/i18n/ja-JP/state_of_css.yml
@@ -178,7 +178,7 @@ translations:
     - key: features.logical_properties
       t: Logical Properties
     - key: features.logical_properties.description
-      t: <code>margin-block-start</code>, <code>padding-inline-end</code>, etc.
+      t: <code>margin-block-start</code>, <code>padding-inline-end</code>など
     - key: features.aspect_ratio
       t: <code>aspect-ratio</code>
     - key: features.content_visibility
@@ -196,7 +196,7 @@ translations:
     - key: features.blend_modes
       t: Blend Modes
     - key: features.blend_modes.description
-      t: The <code>mix-blend-mode</code> property
+      t: <code>mix-blend-mode</code>
     - key: features.filter_effects
       t: CSS Filter Effects
     - key: features.backdrop_filter
@@ -216,11 +216,11 @@ translations:
 
     # typography
     - key: features.web_fonts
-      t: Web fonts (@font-face)
+      t: ウェブフォント (@font-face)
     - key: features.variables_fonts
-      t: Variable fonts
+      t: バリアブルフォント
     - key: features.line_breaking
-      t: Line breaking properties
+      t: 改行関連プロパティ
     - key: features.line_breaking.description
       t: <code>overflow-wrap</code>, <code>word-break</code>, <code>line-break</code>, <code>hyphens</code>
     - key: features.font_variant
@@ -238,7 +238,7 @@ translations:
     - key: features.direction
       t: <code>direction</code>
     - key: features.direction.description
-      t: Also includes <code>dir</code> HTML attribute.
+      t: HTMLの<code>dir</code>属性も含む。
 
     # animations & transforms
     - key: features.transitions
@@ -252,7 +252,7 @@ translations:
 
     # media queries
     - key: features.feature_support_queries
-      t: Feature Support Queries (<code>@supports</code>)
+      t: フィーチャークエリー (<code>@supports</code>)
     - key: features.prefers_reduced_motion
       t: <code>prefers-reduced-motion</code>
     - key: features.prefers_color_scheme
@@ -262,7 +262,7 @@ translations:
 
     # other features
     - key: features.variables
-      t: CSS Variables (Custom Properties)
+      t: CSS Variables (カスタムプロパティ)
     - key: features.containment
       t: CSS Containment
     - key: features.will_change
@@ -272,9 +272,9 @@ translations:
     - key: features.houdini
       t: Houdini
     - key: features.comparison_functions
-      t: CSS Comparison Functions
+      t: CSS比較関数
     - key: features.comparison_functions.description
-      t: <code>min()</code>, <code>max()</code>, and <code>clamp()</code>
+      t: <code>min()</code>, <code>max()</code>, <code>clamp()</code>
 
     # knowledge score
     - key: features.knowledge_score
@@ -418,7 +418,7 @@ translations:
     - key: options.links_urls.any_link
       t: :any-link
     - key: options.links_urls.link_visited
-      t: :link and :visited
+      t: :link / :visited
     - key: options.links_urls.local_link
       t: :local-link
     - key: options.links_urls.target
@@ -446,9 +446,9 @@ translations:
       t: フォームコントロール関連セレクタのうち、どれを使ったことがあるか。
 
     - key: options.form_controls.enabled_disabled
-      t: :enabled and :disabled
+      t: :enabled / :disabled
     - key: options.form_controls.read_only_write
-      t: :read-only and :read-write
+      t: :read-only / :read-write
     - key: options.form_controls.placeholder_shown
       t: :placeholder-shown
     - key: options.form_controls.default
@@ -458,13 +458,13 @@ translations:
     - key: options.form_controls.indeterminate
       t: :indeterminate
     - key: options.form_controls.valid_invalid
-      t: :valid and :invalid
+      t: :valid / :invalid
     - key: options.form_controls.user_invalid
       t: :user-invalid
     - key: options.form_controls.in_out_range
-      t: :in-range and :out-of-range
+      t: :in-range / :out-of-range
     - key: options.form_controls.required_optional
-      t: :required and :optional
+      t: :required / :optional
 
     ###########################################################################
     # Environments

--- a/src/i18n/ja-JP/state_of_css.yml
+++ b/src/i18n/ja-JP/state_of_css.yml
@@ -7,16 +7,6 @@ translations:
 
     - key: general.survey_intro_css2020
       t: >
-          CSS is evolving faster than ever.
-
-
-          Flexbox, Grid, Multi-Column… To say nothing of whole new paradigms like CSS-in-JS.
-
-
-          So after the success of our annual State Of JavaScript survey,
-          we’ve decided to take on the world of styles and selectors. We're hoping you’ll help
-          us identify the latest trends, and figure out what tools to learn and use next!
-      t: >
           CSSはこれまでにない速さで進化しています。
 
           Flexbox、Grid、マルチカラム……CSS-in-JSは言うまでもありませんね。
@@ -24,7 +14,6 @@ translations:
           State Of JavaScriptの成功をうけ、対象をスタイルやセレクタの世界にも広げることにしました。このアンケートが、いまのトレンドが何かを知ったり、どのようなツールを使えばいいのかといった疑問の解決の手助けになることを願っています！
 
     - key: general.results.description
-      t: The annual survey about the latest trends in CSS.
       t: CSSの最新トレンドを知るためのアンケート
 
     ###########################################################################
@@ -32,124 +21,90 @@ translations:
     ###########################################################################
 
     - key: sections.layout.title
-      t: Layout
       t: レイアウト
     - key: sections.layout.description
-      t: How do you position elements on the screen?
       t: どうやって画面に要素を配置しますか？
 
     - key: sections.shapes_graphics.title
-      t: Shapes & Graphics
       t: シェイプ＆グラフィクス
     - key: sections.shapes_graphics.description
-      t: Controlling the shape and display of elements.
       t: 要素の形と表示を制御する。
 
     - key: sections.interactions.title
-      t: Interactions
       t: インタラクション
     - key: sections.interactions.description
-      t: Controlling how the user interacts with the page.
       t: ユーザーとページのインタラクションを調整する。
 
     - key: sections.typography.title
-      t: Typography
       t: タイポグラフィ
     - key: sections.typography.description
-      t: Setting and laying out text.
       t: テキストの設定や配置。
 
     - key: sections.animations_transforms.title
-      t: Animations & Transforms
       t: アニメーション＆トランスフォーム
     - key: sections.animations_transforms.description
-      t: Animating and transforming elements.
       t: 要素のアニメーションや変形。
 
     - key: sections.media_queries.title
-      t: Media Queries
       t: メディアクエリー
     - key: sections.media_queries.description
-      t: Ways of adapting your site to the user's device or preferences.
       t: デバイスやユーザーの設定にあわせる。
 
     - key: sections.other_features.title
-      t: Other Features
       t: そのほかの機能
     - key: sections.other_features.description
-      t: Other CSS features.
       t: そのほかのCSSの機能。
 
     - key: sections.units_selectors.title
-      t: Units & Selectors
       t: 単位とセレクタ
     - key: sections.units_selectors.description
-      t: Test your knowledge of CSS units and selectors.
       t: 単位とセレクタの知識をテストします。
 
     - key: sections.pre_post_processors.title
-      t: Pre-/Post-processors
       t: プリプロセサ・ポストプロセサ
     - key: sections.pre_post_processors.description
-      t: Utilities that augment CSS.
       t: CSSを拡張するユーティリティ。
 
     - key: sections.pre_post_processors_others.title
-      t: Other Pre-/Post-processors
       t: そのほかのプリプロセサ・ポストプロセサ
 
     - key: sections.css_frameworks.title
-      t: CSS Frameworks
       t: CSSフレームワーク
     - key: sections.css_frameworks.description
-      t: Libraries that give you pre-made components and styles.
       t: コンポーネントとスタイルを提供するライブラリ。
 
     - key: sections.css_frameworks_others.title
-      t: Other CSS Frameworks
       t: そのほかのCSSフレームワーク
 
     - key: sections.css_methodologies.title
-      t: CSS Methodologies
       t: CSS設計手法
     - key: sections.css_methodologies.description
-      t: Codified ways to write cleaner CSS.
       t: きれいなCSSを書くために体系化された手法。
 
     - key: sections.css_methodologies_others.title
-      t: Other CSS Methodologies.
       t: そのほかのCSS設計手法
 
     - key: sections.css_in_js.title
       t: CSS-in-JS
-      t: CSS-in-JS
     - key: sections.css_in_js.description
-      t: Libraries that help integrate CSS into JavaScript code.
       t: JavaScriptコードにCSSを組み込むためのライブラリ。
 
     - key: sections.css_in_js_others.title
-      t: Other CSS-in-JS Libraries.
       t: そのほかのCSS-in-JSライブラリ。
 
     - key: sections.tools_others.title
-      t: Other Tools
       t: そのほかのツール
     - key: sections.tools_others.description
-      t: Other CSS tools.
       t: そのほかのCSSのツール。
 
     - key: sections.environments.title
-      t: Environments
       t: 対応環境
     - key: sections.environments.description
-      t: Which environments do you write CSS for?
       t: どんな環境に向けてCSSを書いているか。
 
     - key: sections.awards.title
-      t: Awards
       t: アワード
     - key: sections.awards.description
-      t: Things that stood out this year.
       t: 今年注目を集めたものに贈られます。
 
     ###########################################################################
@@ -158,60 +113,44 @@ translations:
 
     # CSS for print
     - key: options.css_for_print.0
-      t: I (almost) never write print styles
       t: 印刷用スタイルは（ほとんど）書いたことがない
     - key: options.css_for_print.0.short
-      t: Never
       t: まったくない
 
     - key: options.css_for_print.1
-      t: I occasionally write print styles
       t: 印刷用スタイルはときどき書く
     - key: options.css_for_print.1.short
-      t: Occasionally
       t: ときどき
 
     - key: options.css_for_print.2
-      t: I write print styles as part of most projects
       t: 印刷用スタイルはほとんどのプロジェクトで書いている
     - key: options.css_for_print.2.short
-      t: Often
       t: かなり
 
     - key: options.css_for_print.3
-      t: I focus mainly on CSS for print
       t: CSSは印刷用スタイルを主に書いている
     - key: options.css_for_print.3.short
-      t: Mainly
       t: 専業
 
     # CSS for email
     - key: options.css_for_email.0
-      t: I (almost) never write CSS for email clients
       t: メール用のCSSは（ほとんど）書いたことがない
     - key: options.css_for_email.0.short
-      t: Never
       t: まったくない
 
     - key: options.css_for_email.1
-      t: I occasionally write CSS for email clients
       t: メール用のCSSはときどき書く
     - key: options.css_for_email.1.short
-      t: Occasionally
       t: ときどき
 
     - key: options.css_for_email.2
-      t: I write CSS for email clients as part of most projects
       t: メール用のCSSはほとんどのプロジェクトで書いている
     - key: options.css_for_email.2.short
-      t: Often
       t: かなり
 
     - key: options.css_for_email.3
-      t: I focus mainly on CSS for email clients
       t: メール用のCSSを主に書いている
     - key: options.css_for_email.3.short
-      t: Mainly
       t: 専業
 
     ###########################################################################
@@ -339,10 +278,8 @@ translations:
 
     # knowledge score
     - key: features.knowledge_score
-      t: Knowledge Score
       t: 知識の度合い
     - key: features.knowledge_score.description
-      t: Out of all the CSS features mentioned in the survey, how many did the respondent know about?
       t: アンケートで取り上げたCSSの機能を回答者がどのくらい知っていたか。
       
     ###########################################################################
@@ -350,10 +287,8 @@ translations:
     ###########################################################################
 
     - key: features_others.units
-      t: Units
       t: 単位
     - key: features_others.units.description
-      t: Which of these CSS units have you used?
       t: どの単位を使ったことがあるか。
 
     - key: options.units.px
@@ -382,10 +317,8 @@ translations:
       t: in
 
     - key: features_others.pseudo_elements
-      t: Pseudo Elements
       t: 疑似要素
     - key: features_others.pseudo_elements.description
-      t: Which of these CSS pseudo-elements have you used?
       t: どの疑似要素を使ったことがあるか。
 
     - key: options.pseudo_elements.before
@@ -406,30 +339,22 @@ translations:
       t: '::backdrop'
 
     - key: features_others.combinators
-      t: Combinators
       t: 結合子セレクタ
     - key: features_others.combinators.description
-      t: Which of these combinations CSS selectors have you used?
       t: CSSセレクタの結合子のうち、どれを使ったことがあるか。
 
     - key: options.combinators.descendant
-      t: div span (descendant)
       t: div span (子孫)
     - key: options.combinators.child
-      t: div > span (child)
       t: div > span (子)
     - key: options.combinators.next_sibling
-      t: div + div (next sibling)
       t: div + div (隣接)
     - key: options.combinators.subsequent_sibling
-      t: div ~ div (subsequent sibling)
       t: div ~ div (兄弟)
 
     - key: features_others.tree_document_structure
-      t: Tree / Document Structure
       t: 木構造・ドキュメント構造
     - key: features_others.tree_document_structure.description
-      t: Which of these structure related CSS selectors have you used?
       t: 構造関連セレクタのうち、どれを使ったことがあるか。
 
     - key: options.tree_document_structure.root
@@ -468,36 +393,26 @@ translations:
       t: :has()
 
     - key: features_others.attributes
-      t: Attributes
       t: 属性セレクタ
     - key: features_others.attributes.description
-      t: Which of these CSS attributes selectors have you used?
       t: 属性セレクタのうち、どれを使ったことがあるか。
 
     - key: options.attributes.presence
-      t: div[foo] (Presence)
       t: div[foo] (属性の存在)
     - key: options.attributes.equality
-      t: div[foo="bar"] (Equality)
       t: div[foo="bar"] (一致)
     - key: options.attributes.starts_with
-      t: div[foo^="bar"] (Starts with)
       t: div[foo^="bar"] (開始)
     - key: options.attributes.ends_with
-      t: div[foo$="bar"] (Ends with)
       t: div[foo$="bar"] (終了)
     - key: options.attributes.contains_word
-      t: div[foo~="bar"] (Contains word)
       t: div[foo~="bar"] (単語の包含)
     - key: options.attributes.contains_substring
-      t: div[foo*="bar"] (Contains substring)
       t: div[foo*="bar"] (文字列の包含)
 
     - key: features_others.links_urls
-      t: Links/URLs
       t: リンク・URL
     - key: features_others.links_urls.description
-      t: Which of these links & URLs related CSS selectors have you used?
       t: リンク・URL関連のセレクタのうち、どれを使ったことがあるか。
 
     - key: options.links_urls.any_link
@@ -510,10 +425,8 @@ translations:
       t: :target
 
     - key: features_others.interaction
-      t: Interaction
       t: インタラクション
     - key: features_others.interaction.description
-      t: Which of these interaction CSS selectors have you used?
       t: インタラクション関連セレクタのうち、どれを使ったことがあるか。
 
     - key: options.interaction.hover
@@ -528,10 +441,8 @@ translations:
       t: :focus-visible
 
     - key: features_others.form_controls
-      t: Form Controls
       t: フォームコントロール
     - key: features_others.form_controls.description
-      t: Which of these form related CSS selectors have you used?
       t: フォームコントロール関連セレクタのうち、どれを使ったことがあるか。
 
     - key: options.form_controls.enabled_disabled
@@ -560,38 +471,28 @@ translations:
     ###########################################################################
 
     - key: environments.browsers
-      t: Browsers
       t: ブラウザー
     - key: environments.browsers.description
-      t: Which browsers do you test in?
       t: どのブラウザーでテストしているか。
 
     - key: environments.form_factors
-      t: Form Factors
       t: 対応デバイス
     - key: environments.form_factors.description
-      t: Which form factors do you test on?
       t: どんなデバイスでテストしているか。
 
     - key: environments.css_for_print
-      t: CSS for Print
       t: 印刷用スタイル
     - key: environments.css_for_print.description
-      t: Do you write print styles?
       t: 印刷用スタイルを書いているか。
 
     - key: environments.css_for_email
-      t: CSS for Email Clients
       t: メールクライアント用CSS
     - key: environments.css_for_email.description
-      t: Do you write CSS for email clients?
       t: メール用のCSSを書いているか。
 
     - key: charts.axis_legends.css_for_print
-      t: Frequency
       t: 頻度
     - key: charts.axis_legends.css_for_email
-      t: Frequency
       t: 頻度
 
     ###########################################################################
@@ -599,71 +500,50 @@ translations:
     ###########################################################################
 
     - key: opinions.css_easy_to_learn
-      t: CSS is easy to learn
       t: CSSを学ぶのは簡単だ
     - key: opinions.css_easy_to_learn.title
-      t: Learning Curve
       t: 学習曲線
 
     - key: opinions.css_evolving_slowly
-      t: CSS is evolving too slowly
       t: CSSの発展は遅すぎる
     - key: opinions.css_evolving_slowly.title
-      t: Rate of Change
       t: 変化度合い
 
     - key: opinions.utility_classes_to_be_avoided
-      t: Utility (non-semantic) classes (.center, .large-text, etc.) should be avoided
       t: セマンティックではない、ユーティリティクラス（.center、.large-textなど）は避けるべきだ
     - key: opinions.utility_classes_to_be_avoided.title
-      t: Non-Semantic Classes
       t: セマンティックでないクラス
 
     - key: opinions.selector_nesting_to_be_avoided
-      t: Selector nesting (.foo .bar ul li {...}) should be avoided
       t: セレクタの入れ子（.foo .bar ul li {...}）は避けるべきだ
     - key: opinions.selector_nesting_to_be_avoided.title
-      t: Selector Nesting
       t: セレクタの入れ子
 
     - key: opinions.css_is_programming_language
-      t: CSS is a programming language
       t: CSSはプログラミング言語だ
     - key: opinions.css_is_programming_language.title
-      t: Programming Language
       t: プログラミング言語
 
     - key: opinions.enjoy_writing_css
-      t: I enjoy writing CSS
       t: CSSを書いていて楽しい
     - key: opinions.enjoy_writing_css.title
-      t: Enjoyment
       t: 楽しさ
 
     - key: opinions_others.currently_missing_from_css.others
-      t: What do you feel is currently missing from CSS?
       t: CSSにいま足りないものは何か。
     - key: opinions_others.currently_missing_from_css.others.description
-      t: Features you'd like to see in CSS one day.
       t: CSSにいつかほしい機能。
     - key: opinions_others.currently_missing_from_css.others.note
-      t: >
-          These results were normalized based on the contents of a freeform field.
-          To view the raw, unprocessed responses check out [whatsmissingfromcss.com](http://whatsmissingfromcss.com/).
       t: >
           これらの結果は自由入力の内容を正規化したものです。処理されていない生のデータは、[whatsmissingfromcss.com](http://whatsmissingfromcss.com/)からご覧ください。
     
     - key: opinions.sum_up_one_word_css
-      t: CSS in one word
       t: CSSを一言で言うと
     - key: opinions.sum_up_one_word_css.description
-      t: How would you sum up your opinion of CSS in one word?
       t: CSSについて何かひとこと言うなら。
 
     - key: happiness.state_of_the_web
-      t: How happy are you with the general state of web technologies?
       t: ウェブ技術の現状に満足しているか。
 
     - key: happiness.state_of_css
-      t: How happy are you with the general state of CSS?
       t: CSSの現状に満足しているか。

--- a/src/i18n/ja-JP/state_of_css.yml
+++ b/src/i18n/ja-JP/state_of_css.yml
@@ -1,4 +1,4 @@
-locale: en-US
+locale: ja-JP
 namespace: css
 translations:
     ###########################################################################
@@ -17,19 +17,15 @@ translations:
           we’ve decided to take on the world of styles and selectors. We're hoping you’ll help
           us identify the latest trends, and figure out what tools to learn and use next!
       t: >
-          CSS is evolving faster than ever.
+          CSSはこれまでにない速さで進化しています。
 
+          Flexbox、Grid、マルチカラム……CSS-in-JSは言うまでもありませんね。
 
-          Flexbox, Grid, Multi-Column… To say nothing of whole new paradigms like CSS-in-JS.
-
-
-          So after the success of our annual State Of JavaScript survey,
-          we’ve decided to take on the world of styles and selectors. We're hoping you’ll help
-          us identify the latest trends, and figure out what tools to learn and use next!
+          State Of JavaScriptの成功をうけ、対象をスタイルやセレクタの世界にも広げることにしました。このアンケートが、いまのトレンドが何かを知ったり、どのようなツールを使えばいいのかといった疑問の解決の手助けになることを願っています！
 
     - key: general.results.description
       t: The annual survey about the latest trends in CSS.
-      t: The annual survey about the latest trends in CSS.
+      t: CSSの最新トレンドを知るためのアンケート
 
     ###########################################################################
     # Sections
@@ -37,124 +33,124 @@ translations:
 
     - key: sections.layout.title
       t: Layout
-      t: Layout
+      t: レイアウト
     - key: sections.layout.description
       t: How do you position elements on the screen?
-      t: How do you position elements on the screen?
+      t: どうやって画面に要素を配置しますか？
 
     - key: sections.shapes_graphics.title
       t: Shapes & Graphics
-      t: Shapes & Graphics
+      t: 形状とグラフィクス
     - key: sections.shapes_graphics.description
       t: Controlling the shape and display of elements.
-      t: Controlling the shape and display of elements.
+      t: 要素の形状と表示を制御する。
 
     - key: sections.interactions.title
       t: Interactions
-      t: Interactions
+      t: インタラクション
     - key: sections.interactions.description
       t: Controlling how the user interacts with the page.
-      t: Controlling how the user interacts with the page.
+      t: ユーザーがどのようにページに触れるかを制御する。
 
     - key: sections.typography.title
       t: Typography
-      t: Typography
+      t: タイポグラフィ
     - key: sections.typography.description
       t: Setting and laying out text.
-      t: Setting and laying out text.
+      t: テキストの設定や配置。
 
     - key: sections.animations_transforms.title
       t: Animations & Transforms
-      t: Animations & Transforms
+      t: アニメーション＆トランスフォーム
     - key: sections.animations_transforms.description
       t: Animating and transforming elements.
-      t: Animating and transforming elements.
+      t: 要素をアニメーションさせたり、変形させたりします。
 
     - key: sections.media_queries.title
       t: Media Queries
-      t: Media Queries
+      t: メディアクエリー
     - key: sections.media_queries.description
       t: Ways of adapting your site to the user's device or preferences.
-      t: Ways of adapting your site to the user's device or preferences.
+      t: ユーザーのデバイスや設定に沿うようサイトを調整します。
 
     - key: sections.other_features.title
       t: Other Features
-      t: Other Features
+      t: そのほかの機能
     - key: sections.other_features.description
       t: Other CSS features.
-      t: Other CSS features.
+      t: そのほかのCSSの機能
 
     - key: sections.units_selectors.title
       t: Units & Selectors
-      t: Units & Selectors
+      t: 単位とセレクタ
     - key: sections.units_selectors.description
       t: Test your knowledge of CSS units and selectors.
-      t: Test your knowledge of CSS units and selectors.
+      t: 単位とセレクタの知識をテストします。
 
     - key: sections.pre_post_processors.title
       t: Pre-/Post-processors
-      t: Pre-/Post-processors
+      t: プリプロセサ・ポストプロセサ
     - key: sections.pre_post_processors.description
       t: Utilities that augment CSS.
-      t: Utilities that augment CSS.
+      t: CSSを拡張するユーティリティ。
 
     - key: sections.pre_post_processors_others.title
       t: Other Pre-/Post-processors
-      t: Other Pre-/Post-processors
+      t: そのほかのプリプロセサ・ポストプロセサ
 
     - key: sections.css_frameworks.title
       t: CSS Frameworks
-      t: CSS Frameworks
+      t: CSSフレームワーク
     - key: sections.css_frameworks.description
       t: Libraries that give you pre-made components and styles.
-      t: Libraries that give you pre-made components and styles.
+      t: 定義済みのコンポーネントとそのスタイルを提供するライブラリ。
 
     - key: sections.css_frameworks_others.title
       t: Other CSS Frameworks
-      t: Other CSS Frameworks
+      t: そのほかのCSSフレームワーク
 
     - key: sections.css_methodologies.title
       t: CSS Methodologies
-      t: CSS Methodologies
+      t: CSS設計手法
     - key: sections.css_methodologies.description
       t: Codified ways to write cleaner CSS.
-      t: Codified ways to write cleaner CSS.
+      t: きれいなCSSを書くためのcodified手法。
 
     - key: sections.css_methodologies_others.title
       t: Other CSS Methodologies.
-      t: Other CSS Methodologies.
+      t: そのほかのCSS設計手法
 
     - key: sections.css_in_js.title
       t: CSS-in-JS
       t: CSS-in-JS
     - key: sections.css_in_js.description
       t: Libraries that help integrate CSS into JavaScript code.
-      t: Libraries that help integrate CSS into JavaScript code.
+      t: JavaScriptコードにCSSを組み込むためのライブラリ。
 
     - key: sections.css_in_js_others.title
       t: Other CSS-in-JS Libraries.
-      t: Other CSS-in-JS Libraries.
+      t: そのほかのCSS-in-JSライブラリ。
 
     - key: sections.tools_others.title
       t: Other Tools
-      t: Other Tools
+      t: そのほかのツール
     - key: sections.tools_others.description
       t: Other CSS tools.
-      t: Other CSS tools.
+      t: そのほかのCSSのツール。
 
     - key: sections.environments.title
       t: Environments
       t: Environments
     - key: sections.environments.description
       t: Which environments do you write CSS for?
-      t: Which environments do you write CSS for?
+      t: どんな環境に向けてCSSを書いているか。
 
     - key: sections.awards.title
       t: Awards
-      t: Awards
+      t: アワード
     - key: sections.awards.description
       t: Things that stood out this year.
-      t: Things that stood out this year.
+      t: 今年注目を集めたものに贈られます。
 
     ###########################################################################
     # Options
@@ -163,60 +159,60 @@ translations:
     # CSS for print
     - key: options.css_for_print.0
       t: I (almost) never write print styles
-      t: I (almost) never write print styles
+      t: 印刷用スタイルは（ほとんど）書いたことがない
     - key: options.css_for_print.0.short
       t: Never
-      t: Never
+      t: まったくない
 
     - key: options.css_for_print.1
       t: I occasionally write print styles
-      t: I occasionally write print styles
+      t: 印刷用スタイルはときどき書く
     - key: options.css_for_print.1.short
       t: Occasionally
-      t: Occasionally
+      t: ときどき
 
     - key: options.css_for_print.2
       t: I write print styles as part of most projects
-      t: I write print styles as part of most projects
+      t: 印刷用スタイルはほとんどのプロジェクトで書いている
     - key: options.css_for_print.2.short
       t: Often
-      t: Often
+      t: かなり
 
     - key: options.css_for_print.3
       t: I focus mainly on CSS for print
-      t: I focus mainly on CSS for print
+      t: CSSは印刷用スタイルだけ書いている
     - key: options.css_for_print.3.short
       t: Mainly
-      t: Mainly
+      t: 専業
 
     # CSS for email
     - key: options.css_for_email.0
       t: I (almost) never write CSS for email clients
-      t: I (almost) never write CSS for email clients
+      t: メール用のCSSは（ほとんど）書いたことがない
     - key: options.css_for_email.0.short
       t: Never
-      t: Never
+      t: まったくない
 
     - key: options.css_for_email.1
       t: I occasionally write CSS for email clients
-      t: I occasionally write CSS for email clients
+      t: メール用のCSSはときどき書く
     - key: options.css_for_email.1.short
       t: Occasionally
-      t: Occasionally
+      t: ときどき
 
     - key: options.css_for_email.2
       t: I write CSS for email clients as part of most projects
-      t: I write CSS for email clients as part of most projects
+      t: メール用のCSSはほとんどのプロジェクトで書いている
     - key: options.css_for_email.2.short
       t: Often
-      t: Often
+      t: かなり
 
     - key: options.css_for_email.3
       t: I focus mainly on CSS for email clients
-      t: I focus mainly on CSS for email clients
+      t: メール用のCSSだけ書いている
     - key: options.css_for_email.3.short
       t: Mainly
-      t: Mainly
+      t: 専業
 
     ###########################################################################
     # Features
@@ -344,10 +340,10 @@ translations:
     # knowledge score
     - key: features.knowledge_score
       t: Knowledge Score
-      t: Knowledge Score
+      t: 知識の度合い
     - key: features.knowledge_score.description
       t: Out of all the CSS features mentioned in the survey, how many did the respondent know about?
-      t: Out of all the CSS features mentioned in the survey, how many did the respondent know about?
+      t: アンケートで取り上げたCSSの機能を回答者がどのくらい知っていたか。
       
     ###########################################################################
     # Units & Selectors
@@ -355,10 +351,10 @@ translations:
 
     - key: features_others.units
       t: Units
-      t: Units
+      t: 単位
     - key: features_others.units.description
       t: Which of these CSS units have you used?
-      t: Which of these CSS units have you used?
+      t: どの単位を使ったことがあるか。
 
     - key: options.units.px
       t: px
@@ -387,10 +383,10 @@ translations:
 
     - key: features_others.pseudo_elements
       t: Pseudo Elements
-      t: Pseudo Elements
+      t: 疑似要素
     - key: features_others.pseudo_elements.description
       t: Which of these CSS pseudo-elements have you used?
-      t: Which of these CSS pseudo-elements have you used?
+      t: どの疑似要素を使ったことがあるか。
 
     - key: options.pseudo_elements.before
       t: '::before'
@@ -411,30 +407,30 @@ translations:
 
     - key: features_others.combinators
       t: Combinators
-      t: Combinators
+      t: 結合子セレクタ
     - key: features_others.combinators.description
       t: Which of these combinations CSS selectors have you used?
-      t: Which of these combinations CSS selectors have you used?
+      t: CSSセレクタの結合子のうち、どれを使ったことがあるか。
 
     - key: options.combinators.descendant
       t: div span (descendant)
-      t: div span (descendant)
+      t: div span (子孫)
     - key: options.combinators.child
       t: div > span (child)
-      t: div > span (child)
+      t: div > span (子)
     - key: options.combinators.next_sibling
       t: div + div (next sibling)
-      t: div + div (next sibling)
+      t: div + div (隣接)
     - key: options.combinators.subsequent_sibling
       t: div ~ div (subsequent sibling)
-      t: div ~ div (subsequent sibling)
+      t: div ~ div (兄弟)
 
     - key: features_others.tree_document_structure
       t: Tree / Document Structure
-      t: Tree / Document Structure
+      t: 木構造・ドキュメント構造
     - key: features_others.tree_document_structure.description
       t: Which of these structure related CSS selectors have you used?
-      t: Which of these structure related CSS selectors have you used?
+      t: 構造関連セレクタのうち、どれを使ったことがあるか。
 
     - key: options.tree_document_structure.root
       t: :root
@@ -473,36 +469,36 @@ translations:
 
     - key: features_others.attributes
       t: Attributes
-      t: Attributes
+      t: 属性セレクタ
     - key: features_others.attributes.description
       t: Which of these CSS attributes selectors have you used?
-      t: Which of these CSS attributes selectors have you used?
+      t: 属性セレクタのうち、どれを使ったことがあるか。
 
     - key: options.attributes.presence
       t: div[foo] (Presence)
-      t: div[foo] (Presence)
+      t: div[foo] (属性の存在)
     - key: options.attributes.equality
       t: div[foo="bar"] (Equality)
-      t: div[foo="bar"] (Equality)
+      t: div[foo="bar"] (一致)
     - key: options.attributes.starts_with
       t: div[foo^="bar"] (Starts with)
-      t: div[foo^="bar"] (Starts with)
+      t: div[foo^="bar"] (開始)
     - key: options.attributes.ends_with
       t: div[foo$="bar"] (Ends with)
-      t: div[foo$="bar"] (Ends with)
+      t: div[foo$="bar"] (終了)
     - key: options.attributes.contains_word
       t: div[foo~="bar"] (Contains word)
-      t: div[foo~="bar"] (Contains word)
+      t: div[foo~="bar"] (単語の包含)
     - key: options.attributes.contains_substring
       t: div[foo*="bar"] (Contains substring)
-      t: div[foo*="bar"] (Contains substring)
+      t: div[foo*="bar"] (文字列の包含)
 
     - key: features_others.links_urls
       t: Links/URLs
-      t: Links/URLs
+      t: リンク・URL
     - key: features_others.links_urls.description
       t: Which of these links & URLs related CSS selectors have you used?
-      t: Which of these links & URLs related CSS selectors have you used?
+      t: リンク・URL関連のセレクタのうち、どれを使ったことがあるか。
 
     - key: options.links_urls.any_link
       t: :any-link
@@ -515,10 +511,10 @@ translations:
 
     - key: features_others.interaction
       t: Interaction
-      t: Interaction
+      t: インタラクション
     - key: features_others.interaction.description
       t: Which of these interaction CSS selectors have you used?
-      t: Which of these interaction CSS selectors have you used?
+      t: インタラクション関連セレクタのうち、どれを使ったことがあるか。
 
     - key: options.interaction.hover
       t: :hover
@@ -533,10 +529,10 @@ translations:
 
     - key: features_others.form_controls
       t: Form Controls
-      t: Form Controls
+      t: フォームコントロール
     - key: features_others.form_controls.description
       t: Which of these form related CSS selectors have you used?
-      t: Which of these form related CSS selectors have you used?
+      t: フォームコントロール関連セレクタのうち、どれを使ったことがあるか。
 
     - key: options.form_controls.enabled_disabled
       t: :enabled and :disabled
@@ -565,38 +561,38 @@ translations:
 
     - key: environments.browsers
       t: Browsers
-      t: Browsers
+      t: ブラウザー
     - key: environments.browsers.description
       t: Which browsers do you test in?
-      t: Which browsers do you test in?
+      t: どのブラウザーでテストしているか。
 
     - key: environments.form_factors
       t: Form Factors
-      t: Form Factors
+      t: 対応デバイス
     - key: environments.form_factors.description
       t: Which form factors do you test on?
-      t: Which form factors do you test on?
+      t: どんなデバイスでテストしているか。
 
     - key: environments.css_for_print
       t: CSS for Print
-      t: CSS for Print
+      t: 印刷用スタイル
     - key: environments.css_for_print.description
       t: Do you write print styles?
-      t: Do you write print styles?
+      t: 印刷用スタイルを書いているか。
 
     - key: environments.css_for_email
       t: CSS for Email Clients
-      t: CSS for Email Clients
+      t: メールクライアント用CSS
     - key: environments.css_for_email.description
       t: Do you write CSS for email clients?
-      t: Do you write CSS for email clients?
+      t: メール用のCSSを書いているか。
 
     - key: charts.axis_legends.css_for_print
       t: Frequency
-      t: Frequency
+      t: 頻度
     - key: charts.axis_legends.css_for_email
       t: Frequency
-      t: Frequency
+      t: 頻度
 
     ###########################################################################
     # Opinions
@@ -604,68 +600,70 @@ translations:
 
     - key: opinions.css_easy_to_learn
       t: CSS is easy to learn
-      t: CSS is easy to learn
+      t: CSSを学ぶのは簡単だ
     - key: opinions.css_easy_to_learn.title
       t: Learning Curve
-      t: Learning Curve
+      t: 学習曲線
 
     - key: opinions.css_evolving_slowly
       t: CSS is evolving too slowly
-      t: CSS is evolving too slowly
+      t: CSSの発展は遅すぎる
     - key: opinions.css_evolving_slowly.title
       t: Rate of Change
-      t: Rate of Change
+      t: 変化度合い
 
     - key: opinions.utility_classes_to_be_avoided
       t: Utility (non-semantic) classes (.center, .large-text, etc.) should be avoided
-      t: Utility (non-semantic) classes (.center, .large-text, etc.) should be avoided
+      t: セマンティックではない、ユーティリティクラス（.center、.large-textなど）は避けるべきだ
     - key: opinions.utility_classes_to_be_avoided.title
       t: Non-Semantic Classes
-      t: Non-Semantic Classes
+      t: セマンティックでないクラス
 
     - key: opinions.selector_nesting_to_be_avoided
       t: Selector nesting (.foo .bar ul li {...}) should be avoided
-      t: Selector nesting (.foo .bar ul li {...}) should be avoided
+      t: セレクタの入れ子（.foo .bar ul li {...}）は避けるべきだ
     - key: opinions.selector_nesting_to_be_avoided.title
       t: Selector Nesting
-      t: Selector Nesting
+      t: セレクタの入れ子
 
     - key: opinions.css_is_programming_language
       t: CSS is a programming language
-      t: CSS is a programming language
+      t: CSSはプログラミング言語だ
     - key: opinions.css_is_programming_language.title
       t: Programming Language
-      t: Programming Language
+      t: プログラミング言語
 
     - key: opinions.enjoy_writing_css
       t: I enjoy writing CSS
-      t: I enjoy writing CSS
+      t: CSSを書いていて楽しい
     - key: opinions.enjoy_writing_css.title
       t: Enjoyment
-      t: Enjoyment
+      t: 楽しさ
 
     - key: opinions_others.currently_missing_from_css.others
       t: What do you feel is currently missing from CSS?
-      t: What do you feel is currently missing from CSS?
+      t: CSSにいま足りないものは何だと思っているか。
     - key: opinions_others.currently_missing_from_css.others.description
       t: Features you'd like to see in CSS one day.
-      t: Features you'd like to see in CSS one day.
+      t: CSSにいつかほしい機能。
     - key: opinions_others.currently_missing_from_css.others.note
       t: >
           These results were normalized based on the contents of a freeform field.
           To view the raw, unprocessed responses check out [whatsmissingfromcss.com](http://whatsmissingfromcss.com/).
+      t: >
+          これらの結果は自由入力の内容を正規化したものです。処理されていない生のデータは、[whatsmissingfromcss.com](http://whatsmissingfromcss.com/)からご覧ください。
     
     - key: opinions.sum_up_one_word_css
       t: CSS in one word
-      t: CSS in one word
+      t: CSSを一言で言うと
     - key: opinions.sum_up_one_word_css.description
       t: How would you sum up your opinion of CSS in one word?
-      t: How would you sum up your opinion of CSS in one word?
+      t: CSSについて何か一言で意見を言うなら。
 
     - key: happiness.state_of_the_web
       t: How happy are you with the general state of web technologies?
-      t: How happy are you with the general state of web technologies?
+      t: ウェブ技術の現状に満足しているか。
 
     - key: happiness.state_of_css
       t: How happy are you with the general state of CSS?
-      t: How happy are you with the general state of CSS?
+      t: CSSの現状に満足しているか。

--- a/src/i18n/ja-JP/state_of_css_2020.yml
+++ b/src/i18n/ja-JP/state_of_css_2020.yml
@@ -39,7 +39,7 @@ translations:
           ### Credits & Stuff
 
           このサイトで使われている書体はIBM Plex Monoです。
-          
+
           質問やフィードバックがあればぜひ[教えてください！](mailto:hello@stateofjs.com)
 
           では、2020年のCSSについて見てみましょう！
@@ -256,7 +256,7 @@ translations:
           Sergio has recently fixed lots of Flexbox in WebKit and even some in Chromium, 
           notably bringing flex gap to WebKit, 
           which means that soon it will be available on all modern browsers. 
-    
+
     - key: picks.jina.bio
       t: Design systems advocate and practitioner
     - key: picks.jina.description

--- a/src/i18n/ja-JP/state_of_css_2020.yml
+++ b/src/i18n/ja-JP/state_of_css_2020.yml
@@ -1,4 +1,4 @@
-locale: en-US
+locale: ja-JP
 translations:
     ###########################################################################
     # Introduction
@@ -45,42 +45,43 @@ translations:
 
             <span class="conclusion__byline">– Sacha and Raphaël</span>
       t: |
+            <span class="first-letter">忘</span>れましょう、CSSについて知っているすべてを。忘れられなくても、多くのことを見直す準備はしておきましょう。あなたが私と同じく、10年以上CSSを書いているひとなら、2020年のCSSは私たちが慣れ親しんだものとまったくもって違うものに見えるでしょう。
 
-            <span class="first-letter">F</span>orget everything you know about CSS. Or at least, be ready to reconsider a lot of it. If like me you've been writing CSS for over a decade, CSS in 2020 looks nothing like what you were used to.
+            ブレークポイントの代わりにCSS Gridを使えば、様々はビューポートの大きさに対応するレスポンシブなレイアウトを、ずっと短いコードで書けます。グローバルなスタイルシートではなく、CSS-in-JSを使ってコンポーネントとスタイルを同じ場所に置くと、テーマのカスタマイズをしやすいデザインシステムを実現できます。
 
-            Instead of breakpoints, we can now leverage CSS Grid to make dynamic, responsive layouts that adapt to any viewport size with fewer lines of code. Instead of relying on global stylesheets, CSS-in-JS lets us colocate our styles with our components to build themeable design systems.
+            ほとんどの人にとって、Tailwind CSSは突然現れたものだったでしょう。そのユーティリティファーストなCSSという思想により、セマンティックなクラス名をつけようというこれまでの教えを考え直させました。
 
-            And most of all, Tailwind CSS has burst onto the scene and, through its use of utility-first CSS, forced us to reconsider the traditional dogma of semantic class names.
+            これらの変化は、意気がったブログ記事や荒れたツイートを生み出してしまうかもしれません。このサイトの提供するデータや、トレンドのハイライトが、来年も慌ただしくなるであろうCSS界を進む手助けになることを祈っています。
 
-            Whether all this change makes you want to write a hyped-up blog post or an angry Twitter rant, we are here to present the data, highlight the trends, and hopefully guide you through another eventful year of CSS!
+            ### チーム
 
-            ### Team
+            State of CSSは、私たちが開発・管理しています。
 
-            The State of CSS Survey is created and maintained by:
+            - [Sacha Greif](https://twitter.com/sachagreif): デザイン、ライティング、コーディング
+            - [Raphaël Benitte](https://twitter.com/benitteraphael): データ分析、ビジュアリゼーション
 
-            - [Sacha Greif](https://twitter.com/sachagreif): Design, writing, coding
-            - [Raphaël Benitte](https://twitter.com/benitteraphael): Data analysis, data visualizations
+            ### データのダウンロード
 
-            ### Download Our Data
+            [アンケートの回答データ（JSON）をダウンロードできます](https://www.kaggle.com/sachag/state-of-css)。何か新しいビジュアリゼーションをつくったら、ぜひ教えてください。
 
-            You can [download the raw JSON data for this survey](https://www.kaggle.com/sachag/state-of-css). Let us know if you end up making your own data visualizations!
+            ### そのほかのリンク
 
-            ### Other Links
-
-            - [State of CSS Homepage](https://stateofcss.com)
+            - [State of CSSホームページ](https://stateofcss.com)
             - [State of JS](https://stateofjs.com)
 
             ### Thanks
 
-            Thanks to all the people who helped us design the survey, including [Chen Hui-Jing](http://chenhuijing.com/), [Philip Jägenstedt](https://blog.foolip.org/), [Adam Argyke](https://nerdy.dev/), [Ahmad Shadeed](https://www.ishadeed.com/), [Robert Flack](https://github.com/flackr), [Dominic Nguyen](https://www.chromatic.com/), [Fantasai](http://fantasai.inkedblade.net/), and [Kilian Valkhof](https://kilianvalkhof.com/).
+            アンケートの設計を手伝ってくれたみなさん、とくに[Chen Hui-Jing](http://chenhuijing.com/)、[Philip Jägenstedt](https://blog.foolip.org/)、[Adam Argyke](https://nerdy.dev/)、[Ahmad Shadeed](https://www.ishadeed.com/)、[Robert Flack](https://github.com/flackr)、[Dominic Nguyen](https://www.chromatic.com/)、[Fantasai](http://fantasai.inkedblade.net/)、[Kilian Valkhof](https://kilianvalkhof.com/)に感謝します。
 
-            Additional thanks to [Alexey Pyltsyn](https://github.com/lex111) for his help with translations.  
+            翻訳について手伝ってくれた[Alexey Pyltsyn](https://github.com/lex111)にも感謝します。
 
             ### Credits & Stuff
 
-            The site is set in IBM Plex Mono. Questions? Feedback? [Get in touch!](mailto:hello@stateofjs.com)
+            このサイトで使われている書体はIBM Plex Monoです。
+            
+            質問やフィードバックがあればぜひ[教えてください！](mailto:hello@stateofjs.com)
 
-            And now, let's see what CSS has been up to this year!
+            では、2020年のCSSについて見てみましょう！
 
             <span class="conclusion__byline">– Sacha and Raphaël</span>
 
@@ -90,7 +91,7 @@ translations:
 
     - key: sections.tshirt.title
       t: T-shirt
-      t: T-shirt
+      t: Tシャツ
 
     - key: sections.tshirt.description
       t: |
@@ -102,17 +103,17 @@ translations:
 
           So whether you're going to a conference, a job interview, or just work, this shirt will demonstrate your CSS mastery like no other garment can!
       t: |
-          ## Support the survey and look good in the process!
+          ## アンケートをサポートしておしゃれになろう！
 
-          A quick announcement before the survey results. Introducing our very own 🎈🎉👕 State of CSS T-shirt 👕🎉🎈!
+          結果の前に、すこしお知らせをさせてください。🎈🎉👕 State of CSS Tシャツ 👕🎉🎈 ができました！
 
-          What makes this shirt truly special is that it's the only piece of clothing that also teaches you practical, real-world CSS techniques.
+          このTシャツの何がすごいかというと、実際のCSSテクニックを教えてくれるただひとつの衣類なのです。
 
-          So whether you're going to a conference, a job interview, or just work, this shirt will demonstrate your CSS mastery like no other garment can!
+          カンファレンスでも、面接でも、仕事でも、このTシャツはあなたがCSSに精通していることを示してくれます。ほかのTシャツではこうはいきませんよ！
     
     - key: tshirt.about
       t: About the T-shirt
-      t: About the T-shirt
+      t: Tシャツについて
 
     - key: tshirt.description
       t: |
@@ -121,18 +122,17 @@ translations:
           We use a high-quality, super-soft tri-blend shirt with a slim fit. 
           This shirt sizes small, so if you prefer a looser fit we recommend ordering one size up from what you usually wear (I'm wearing an M in the photos).
       t: |
-          The shirt features the State of CSS logo along with snippets of the actual CSS code used to create each shape. Who knows, you might learn a thing or two!
+          このTシャツはState of CSSのロゴと、その実装に使ったCSSのコードをプリントしています。もしかすると、何か新たに学べるかもしれませんよ！
 
-          We use a high-quality, super-soft tri-blend shirt with a slim fit. 
-          This shirt sizes small, so if you prefer a looser fit we recommend ordering one size up from what you usually wear (I'm wearing an M in the photos).
+          このTシャツは、高品質でとてもやわらかなトライブレンドの生地を使っています。スリムフィットなので、ゆったり着たい場合にはいつものサイズのひとつ上をおすすめします（写真はMを着用）。
 
     - key: tshirt.getit
       t: Get It
-      t: Get It
+      t: 購入する
 
     - key: tshirt.price
       t: USD $24 + shipping
-      t: USD $24 + shipping
+      t: 24ドル（＋送料）
 
     ###########################################################################
     # Sections Introductions
@@ -143,22 +143,20 @@ translations:
           This year's survey reached **11,492** people in **102** countries. For the first time this year,
           we were able to translate the survey questions in multiple languages thanks to an awesome team of volunteers.
       t: |
-          This year's survey reached **11,492** people in **102** countries. For the first time this year,
-          we were able to translate the survey questions in multiple languages thanks to an awesome team of volunteers.
+          今年のアンケートは**102**か国、**11,492**人もの人が回答してくれました。また、すばらしい翻訳ボランティアのみなさんの力により、今回初めて複数の言語で結果をお届けできるようになりました。
 
     - key: sections.features.description
       t: |
           CSS has seen a surge of new features in recent years, so as you'd expect adoption is
           lagging a bit behind as the community takes its time to absorb new properties.
       t: |
-          CSS has seen a surge of new features in recent years, so as you'd expect adoption is
-          lagging a bit behind as the community takes its time to absorb new properties.
+          CSSはここ数年、新しい機能が急増しています。新しいプロパティが使われるまでには時間がかかるので、機能の普及は少し遅れてやってくるでしょう。
 
     - key: sections.units_selectors.description
       t: |
           We're willing to bet you'll find a few things you didn't know about in this section!
       t: |
-          We're willing to bet you'll find a few things you didn't know about in this section!
+          知らなかったことがきっとあるはずです！賭けてもいいですよ。
 
     - key: sections.technologies.description
       t: |
@@ -166,17 +164,14 @@ translations:
           now have to accomodate newer entrants like Tailwind CSS. To say nothing of the whole CSS-in-JS
           movement which, while it has yet to cross over to the CSS mainstream, is nonetheless quite dynamic. 
       t: |
-          The CSS ecosystem is going through a renewal of sorts, as older mainstays like Bootstrap 
-          now have to accomodate newer entrants like Tailwind CSS. To say nothing of the whole CSS-in-JS
-          movement which, while it has yet to cross over to the CSS mainstream, is nonetheless quite dynamic. 
+          CSSのエコシステムはリニューアルの流れにあります。Bootstrapのようなベテランの主力がいる中に、新たにTailwind CSSなどの新人が登場しました。CSS-in-JSのムーブメントは言わずもがなです。メインストリームなCSSとのクロスオーバーが実現しているとはまだ言えませんが、とても強い流れであるのは間違いありません。
 
     - key: sections.other_tools.description
       t: |
           No big surprises here, but it's worth highlighting the appearance of development-focused browsers
           like Polypane and Sizzy, which go a step further than traditional devtools.
       t: |
-          No big surprises here, but it's worth highlighting the appearance of development-focused browsers
-          like Polypane and Sizzy, which go a step further than traditional devtools.
+          特に驚きはないでしょう。しかし、旧来の開発者ツールより一歩踏み込み、開発にフォーカスしたPolypaneやSizzyなどのブラウザが登場したことは注目に値するでしょう。
 
     - key: sections.environments.description
       t: |
@@ -184,9 +179,7 @@ translations:
           of reasons media like print and email remain unexplored by a majority of CSS developers. Might they
           turn out to be the next frontier of CSS…?
       t: |
-          One of CSS's core strengths is its ability to adapt to different environment, yet for a variety
-          of reasons media like print and email remain unexplored by a majority of CSS developers. Might they
-          turn out to be the next frontier of CSS…?
+          CSSが元来持っている強みのひとつに、異なる環境に適応できることがあります。しかし印刷メディアやメールなど、CSS開発者のほとんどが踏み入れていない領域もあります。これらがCSSの次のフロンティアになるかもしれませんよ…？
 
     - key: sections.resources.description
       t: |
@@ -194,17 +187,14 @@ translations:
           and feature many outstanding blogs and podcasts which we are looking forward to officially adding
           to the survey next year!
       t: |
-          The “other answers” results in this section highlight the richness and diversity of the CSS community,
-          and feature many outstanding blogs and podcasts which we are looking forward to officially adding
-          to the survey next year!
+          「そのほかの回答」に書かれた回答が、CSSコミュニティの豊かさ、多様さを表していることが分かります。みなさんが取り上げたブログやポッドキャストが、来年のアンケートの選択肢に加わるかもしれません！
 
     - key: sections.opinions.description
       t: |
           These opinions paint a picture of a language getting more mature, but also more complex. And perhaps
           –at least while we struggle to keep up with the pace of change– a little less enjoyable?
       t: |
-          These opinions paint a picture of a language getting more mature, but also more complex. And perhaps
-          –at least while we struggle to keep up with the pace of change– a little less enjoyable?
+          みなさんの意見が、言語がより成熟してきたこと、一方で複雑になったことをうかがわせます。そして、変化のペースについていくのが大変なことをふまえると、私たちはCSSをあまり楽しめていないのかもしれません。
 
           
     ###########################################################################
@@ -215,13 +205,13 @@ translations:
       t: |
           If you're interested in learning more, we [wrote a blog post](https://dev.to/sachagreif/is-our-survey-biased-against-women-49oj) that addresses the survey's gender dynamics.
       t: |
-          If you're interested in learning more, we [wrote a blog post](https://dev.to/sachagreif/is-our-survey-biased-against-women-49oj) that addresses the survey's gender dynamics.
+          回答者のジェンダーのバランスについては、[ブログ記事](https://dev.to/sachagreif/is-our-survey-biased-against-women-49oj)を書いています。
 
     - key: blocks.currently_missing_from_css.note
       t: |
           You can explore the full dataset of answers to this question in [this side project](https://whatsmissingfromcss.com/).
       t: |
-          You can explore the full dataset of answers to this question in [this side project](https://whatsmissingfromcss.com/).
+          質問への回答の完全なデータセットは、[サイドプロジェクト](https://whatsmissingfromcss.com/)を立ち上げそこで公開しました。
 
     - key: blocks.source.note
       t: >
@@ -233,15 +223,14 @@ translations:
         - State of CSS: the State of CSS mailing list; also matches `email`, `by email`, etc.
 
         - Work: matches `work`, `colleagues`, `coworkers`, etc.
-      t: >
-      
-        This chart aggregates a mix of referrers, URL parameters, and freeform answers. 
+      t: |
+        このチャートはリファラー、URLパラメーター、自由回答を集計したものです。
 
-        - State of JS: the [State of JS](https://stateofjs.com) mailing list.
+        - State of JS: [State of JS](https://stateofjs.com)のメーリングリストです
 
-        - State of CSS: the State of CSS mailing list; also matches `email`, `by email`, etc.
+        - State of CSS: State of CSSのメーリングリストと、`email`, `by email`といった文言を含めています
 
-        - Work: matches `work`, `colleagues`, `coworkers`, etc.
+        - Work: `work`, `colleagues`, `coworkers`といった文言を集めたものです
 
     ###########################################################################
     # Awards
@@ -249,23 +238,23 @@ translations:
 
     - key: award.feature_adoption_delta_award.comment
       t: With a **{value}** progression in 2020, this was the year CSS Grid crossed over from new technology to established tool.
-      t: With a **{value}** progression in 2020, this was the year CSS Grid crossed over from new technology to established tool.
+      t: 2020年に**{value}**の増加をみせたCSS Gridは、新しい技術からすっかり定着した技術になったといえるでしょう。
 
     - key: award.tool_usage_delta_award.comment
       t: No other tool comes even close to Tailwind CSS's dramatic **{value}** progression over the last year.
-      t: No other tool comes even close to Tailwind CSS's dramatic **{value}** progression over the last year.
+      t: Tailwind CSSの昨年比**{value}**という数字に対抗できるツールはありませんでした。
 
     - key: award.tool_satisfaction_award.comment
       t: PostCSS's **{value}** satisfaction ratio shows that you can't beat doing one thing really, really well.
-      t: PostCSS's **{value}** satisfaction ratio shows that you can't beat doing one thing really, really well.
+      t: PostCSSの**{value}**という満足度は、ひとつのことをとてもうまくやっているプロダクトにかなうものはないことを示しています。
 
     - key: award.tool_interest_award.comment
       t: With a **{value}** ratio, CSS Modules have generated the most interest among CSS developers this year.
-      t: With a **{value}** ratio, CSS Modules have generated the most interest among CSS developers this year.
+      t: \**{value}**という数字から、CSS開発者にとってCSS Modulesがどれだけ興味を集めたかがわかります。
 
     - key: award.most_write_ins_award.comment
       t: Many questions also accepted write-in answers, and with **{value}** mentions PhpStorm was the most popular item overall.
-      t: Many questions also accepted write-in answers, and with **{value}** mentions PhpStorm was the most popular item overall.
+      t: 多くの設問で自由入力欄を設けましたが、最も多かったのが**{value}**件の回答を集めたPhpStormでした。
 
       
     ###########################################################################
@@ -286,17 +275,17 @@ translations:
 
             So while we keep an eye on the shiny new toys popping up on GitHub every week, let's not forget the tools, techniques, and most of all people who have carried the CSS torch up to now. We'll need everybody if we're to keep CSS moving forward into 2021 and beyond!
       t: |
-            If a JavaScript developer writes a line of CSS code, are they now a CSS developer?
-            
-            This programming *kōan* illustrates a clear trend in the web development world: as more and more CSS developers are tasked with learning JavaScript, so are JavaScript developers starting to realize there might be more to this whole CSS thing than just `font-weight: bold;`. 
+            JavaScript開発者がCSSを1行書いたら、もうそれでCSS開発者になったと言えるのでしょうか？
 
-            So asking about “the State of CSS” is inherently a tricky proposition: depending on who you ask you might get completely different answers! And how do you know which one's right?
+            この公案はウェブ開発の世界にある、いまのトレンドを表しています。CSS開発者がどんどんとJavaScriptを学ぶ必要にかられ、またJavaScript開発者も`font-weight: bold;`以外にもCSSがあることに気づき始めているのです。
 
-            Here's another kōan for you: the right answer is that there *is* no right answer. Each of the many tools, methodologies, frameworks, and libraries featured here has its place in the vast front-end ecosystem. 
+            こうなると「CSSの現状」を問うのは、とても難しくなります。相手が誰によるかで答えが変わってしまうからです！様々な答えの中から、どの答えが正しいとどうやって決められるのでしょうか？
 
-            Building a complex React app? Styled Components is a great option. Designing a static landing page? You can't go wrong with Sass! And even though Bootstrap has lost some of its original hype factor, you can't beat it when it comes to sheer number of themes and plugins.
+            ここでもうひとつの公案です。正しい答えは、そんなものなんてないということです。ここで取り上げた多くのツール、設計手法、フレームワーク、ライブラリ、それぞれがフロントエンドのエコシステムの一部を担っているのです。
 
-            So while we keep an eye on the shiny new toys popping up on GitHub every week, let's not forget the tools, techniques, and most of all people who have carried the CSS torch up to now. We'll need everybody if we're to keep CSS moving forward into 2021 and beyond!
+            複雑なReactアプリを作る？Styled Componentsはとてもいいものです。静的なランディングページを作る？Sassを使えばそう間違えは起こしません。一時期のハイプこそ収まってはいますが、テーマやプラグインの数においてBootstrapにかなうものはありません。
+
+            このプロジェクトは今後も、GitHubに毎週のように現れる新しいプロジェクトを見続けますが、ツールやテクニック、そしてなによりCSSの灯りを守ってきた人々を忘れてはいけません。CSSを2021年、そして未来にむけて進めるには、みんなの力が必要なのです！
 
     ###########################################################################
     # Picks

--- a/src/i18n/ja-JP/state_of_css_2020.yml
+++ b/src/i18n/ja-JP/state_of_css_2020.yml
@@ -6,45 +6,6 @@ translations:
 
     - key: sections.introduction.description
       t: |
-
-            <span class="first-letter">F</span>orget everything you know about CSS. Or at least, be ready to reconsider a lot of it. If like me you've been writing CSS for over a decade, CSS in 2020 looks nothing like what you were used to.
-
-            Instead of breakpoints, we can now leverage CSS Grid to make dynamic, responsive layouts that adapt to any viewport size with fewer lines of code. Instead of relying on global stylesheets, CSS-in-JS lets us colocate our styles with our components to build themeable design systems.
-
-            And most of all, Tailwind CSS has burst onto the scene and, through its use of utility-first CSS, forced us to reconsider the traditional dogma of semantic class names.
-
-            Whether all this change makes you want to write a hyped-up blog post or an angry Twitter rant, we are here to present the data, highlight the trends, and hopefully guide you through another eventful year of CSS!
-
-            ### Team
-
-            The State of CSS Survey is created and maintained by:
-
-            - [Sacha Greif](https://twitter.com/sachagreif): Design, writing, coding
-            - [Raphaël Benitte](https://twitter.com/benitteraphael): Data analysis, data visualizations
-
-            ### Download Our Data
-
-            You can [download the raw JSON data for this survey](https://www.kaggle.com/sachag/state-of-css). Let us know if you end up making your own data visualizations!
-
-            ### Other Links
-
-            - [State of CSS Homepage](https://stateofcss.com)
-            - [State of JS](https://stateofjs.com)
-
-            ### Thanks
-
-            Thanks to all the people who helped us design the survey, including [Chen Hui-Jing](http://chenhuijing.com/), [Philip Jägenstedt](https://blog.foolip.org/), [Adam Argyke](https://nerdy.dev/), [Ahmad Shadeed](https://www.ishadeed.com/), [Robert Flack](https://github.com/flackr), [Dominic Nguyen](https://www.chromatic.com/), [Fantasai](http://fantasai.inkedblade.net/), and [Kilian Valkhof](https://kilianvalkhof.com/).
-
-            Additional thanks to [Alexey Pyltsyn](https://github.com/lex111) for his help with translations.  
-
-            ### Credits & Stuff
-
-            The site is set in IBM Plex Mono. Questions? Feedback? [Get in touch!](mailto:hello@stateofjs.com)
-
-            And now, let's see what CSS has been up to this year!
-
-            <span class="conclusion__byline">– Sacha and Raphaël</span>
-      t: |
             <span class="first-letter">忘</span>れましょう、CSSについて知っているすべてを。忘れられなくても、多くのことを見直す準備はしておきましょう。あなたが私と同じく、10年以上CSSを書いているひとなら、2020年のCSSは私たちが慣れ親しんだものとまったくもって違うものに見えるでしょう。
 
             ブレークポイントの代わりにCSS Gridを使えば、様々はビューポートの大きさに対応するレスポンシブなレイアウトを、ずっと短いコードで書けます。グローバルなスタイルシートではなく、CSS-in-JSを使ってコンポーネントとスタイルを同じ場所に置くと、テーマのカスタマイズをしやすいデザインシステムを実現できます。
@@ -90,18 +51,9 @@ translations:
     ###########################################################################
 
     - key: sections.tshirt.title
-      t: T-shirt
       t: Tシャツ
 
     - key: sections.tshirt.description
-      t: |
-          ## Support the survey and look good in the process!
-
-          A quick announcement before the survey results. Introducing our very own 🎈🎉👕 State of CSS T-shirt 👕🎉🎈!
-
-          What makes this shirt truly special is that it's the only piece of clothing that also teaches you practical, real-world CSS techniques.
-
-          So whether you're going to a conference, a job interview, or just work, this shirt will demonstrate your CSS mastery like no other garment can!
       t: |
           ## アンケートをサポートしておしゃれになろう！
 
@@ -112,26 +64,18 @@ translations:
           カンファレンスでも、面接でも、仕事でも、このTシャツはあなたがCSSに精通していることを示してくれます。ほかのTシャツではこうはいきませんよ！
     
     - key: tshirt.about
-      t: About the T-shirt
       t: Tシャツについて
 
     - key: tshirt.description
-      t: |
-          The shirt features the State of CSS logo along with snippets of the actual CSS code used to create each shape. Who knows, you might learn a thing or two!
-
-          We use a high-quality, super-soft tri-blend shirt with a slim fit. 
-          This shirt sizes small, so if you prefer a looser fit we recommend ordering one size up from what you usually wear (I'm wearing an M in the photos).
       t: |
           このTシャツはState of CSSのロゴと、その実装に使ったCSSのコードをプリントしています。もしかすると、何か新たに学べるかもしれませんよ！
 
           このTシャツは、高品質でとてもやわらかなトライブレンドの生地を使っています。スリムフィットなので、ゆったり着たい場合にはいつものサイズのひとつ上をおすすめします（写真はMを着用）。
 
     - key: tshirt.getit
-      t: Get It
       t: 購入する
 
     - key: tshirt.price
-      t: USD $24 + shipping
       t: 24ドル（＋送料）
 
     ###########################################################################
@@ -140,59 +84,33 @@ translations:
 
     - key: sections.user_info.description
       t: |
-          This year's survey reached **11,492** people in **102** countries. For the first time this year,
-          we were able to translate the survey questions in multiple languages thanks to an awesome team of volunteers.
-      t: |
           今年のアンケートは**102**か国、**11,492**人もの人が回答してくれました。また、すばらしい翻訳ボランティアのみなさんの力により、今回初めて複数の言語で結果をお届けできるようになりました。
 
     - key: sections.features.description
-      t: |
-          CSS has seen a surge of new features in recent years, so as you'd expect adoption is
-          lagging a bit behind as the community takes its time to absorb new properties.
       t: |
           CSSはここ数年、新しい機能が急増しています。新しいプロパティが使われるまでには時間がかかるので、機能の普及は少し遅れてやってくるでしょう。
 
     - key: sections.units_selectors.description
       t: |
-          We're willing to bet you'll find a few things you didn't know about in this section!
-      t: |
           知らなかったことがきっとあるはずです！賭けてもいいですよ。
 
     - key: sections.technologies.description
-      t: |
-          The CSS ecosystem is going through a renewal of sorts, as older mainstays like Bootstrap 
-          now have to accomodate newer entrants like Tailwind CSS. To say nothing of the whole CSS-in-JS
-          movement which, while it has yet to cross over to the CSS mainstream, is nonetheless quite dynamic. 
       t: |
           CSSのエコシステムはリニューアルの流れにあります。Bootstrapのようなベテランの主力がいる中に、新たにTailwind CSSなどの新人が登場しました。CSS-in-JSのムーブメントは言わずもがなです。メインストリームなCSSとのクロスオーバーが実現しているとはまだ言えませんが、とても強い流れであるのは間違いありません。
 
     - key: sections.other_tools.description
       t: |
-          No big surprises here, but it's worth highlighting the appearance of development-focused browsers
-          like Polypane and Sizzy, which go a step further than traditional devtools.
-      t: |
           特に驚きはないでしょう。しかし、旧来の開発者ツールより一歩踏み込み、開発にフォーカスしたPolypaneやSizzyなどのブラウザが登場したことは注目に値するでしょう。
 
     - key: sections.environments.description
-      t: |
-          One of CSS's core strengths is its ability to adapt to different environment, yet for a variety
-          of reasons media like print and email remain unexplored by a majority of CSS developers. Might they
-          turn out to be the next frontier of CSS…?
       t: |
           CSSが元来持っている強みのひとつに、異なる環境に適応できることがあります。しかし印刷メディアやメールなど、CSS開発者のほとんどが踏み入れていない領域もあります。これらがCSSの次のフロンティアになるかもしれませんよ…？
 
     - key: sections.resources.description
       t: |
-          The “other answers” results in this section highlight the richness and diversity of the CSS community,
-          and feature many outstanding blogs and podcasts which we are looking forward to officially adding
-          to the survey next year!
-      t: |
           「そのほかの回答」に書かれた回答が、CSSコミュニティの豊かさ、多様さを表していることが分かります。みなさんが取り上げたブログやポッドキャストが、来年のアンケートの選択肢に加わるかもしれません！
 
     - key: sections.opinions.description
-      t: |
-          These opinions paint a picture of a language getting more mature, but also more complex. And perhaps
-          –at least while we struggle to keep up with the pace of change– a little less enjoyable?
       t: |
           みなさんの意見が、言語がより成熟してきたこと、一方で複雑になったことをうかがわせます。そして、変化のペースについていくのが大変なことをふまえると、私たちはCSSをあまり楽しめていないのかもしれません。
 
@@ -203,26 +121,13 @@ translations:
 
     - key: blocks.gender.note
       t: |
-          If you're interested in learning more, we [wrote a blog post](https://dev.to/sachagreif/is-our-survey-biased-against-women-49oj) that addresses the survey's gender dynamics.
-      t: |
           回答者のジェンダーのバランスについては、[ブログ記事](https://dev.to/sachagreif/is-our-survey-biased-against-women-49oj)を書いています。
 
     - key: blocks.currently_missing_from_css.note
       t: |
-          You can explore the full dataset of answers to this question in [this side project](https://whatsmissingfromcss.com/).
-      t: |
           質問への回答の完全なデータセットは、[サイドプロジェクト](https://whatsmissingfromcss.com/)を立ち上げそこで公開しました。
 
     - key: blocks.source.note
-      t: >
-      
-        This chart aggregates a mix of referrers, URL parameters, and freeform answers. 
-
-        - State of JS: the [State of JS](https://stateofjs.com) mailing list.
-
-        - State of CSS: the State of CSS mailing list; also matches `email`, `by email`, etc.
-
-        - Work: matches `work`, `colleagues`, `coworkers`, etc.
       t: |
         このチャートはリファラー、URLパラメーター、自由回答を集計したものです。
 
@@ -237,23 +142,18 @@ translations:
     ###########################################################################
 
     - key: award.feature_adoption_delta_award.comment
-      t: With a **{value}** progression in 2020, this was the year CSS Grid crossed over from new technology to established tool.
       t: 2020年に**{value}**の増加をみせたCSS Gridは、新しい技術からすっかり定着した技術になったといえるでしょう。
 
     - key: award.tool_usage_delta_award.comment
-      t: No other tool comes even close to Tailwind CSS's dramatic **{value}** progression over the last year.
       t: Tailwind CSSの昨年比**{value}**という数字に対抗できるツールはありませんでした。
 
     - key: award.tool_satisfaction_award.comment
-      t: PostCSS's **{value}** satisfaction ratio shows that you can't beat doing one thing really, really well.
       t: PostCSSの**{value}**という満足度は、ひとつのことをとてもうまくやっているプロダクトにかなうものはないことを示しています。
 
     - key: award.tool_interest_award.comment
-      t: With a **{value}** ratio, CSS Modules have generated the most interest among CSS developers this year.
       t: \**{value}**という数字から、CSS開発者にとってCSS Modulesがどれだけ興味を集めたかがわかります。
 
     - key: award.most_write_ins_award.comment
-      t: Many questions also accepted write-in answers, and with **{value}** mentions PhpStorm was the most popular item overall.
       t: 多くの設問で自由入力欄を設けましたが、最も多かったのが**{value}**件の回答を集めたPhpStormでした。
 
       
@@ -262,18 +162,6 @@ translations:
     ###########################################################################
 
     - key: sections.conclusion.description
-      t: |
-            If a JavaScript developer writes a line of CSS code, are they now a CSS developer?
-            
-            This programming *kōan* illustrates a clear trend in the web development world: as more and more CSS developers are tasked with learning JavaScript, so are JavaScript developers starting to realize there might be more to this whole CSS thing than just `font-weight: bold;`. 
-
-            So asking about “the State of CSS” is inherently a tricky proposition: depending on who you ask you might get completely different answers! And how do you know which one's right?
-
-            Here's another kōan for you: the right answer is that there *is* no right answer. Each of the many tools, methodologies, frameworks, and libraries featured here has its place in the vast front-end ecosystem. 
-
-            Building a complex React app? Styled Components is a great option. Designing a static landing page? You can't go wrong with Sass! And even though Bootstrap has lost some of its original hype factor, you can't beat it when it comes to sheer number of themes and plugins.
-
-            So while we keep an eye on the shiny new toys popping up on GitHub every week, let's not forget the tools, techniques, and most of all people who have carried the CSS torch up to now. We'll need everybody if we're to keep CSS moving forward into 2021 and beyond!
       t: |
             JavaScript開発者がCSSを1行書いたら、もうそれでCSS開発者になったと言えるのでしょうか？
 

--- a/src/i18n/ja-JP/state_of_css_2020.yml
+++ b/src/i18n/ja-JP/state_of_css_2020.yml
@@ -44,12 +44,52 @@ translations:
             And now, let's see what CSS has been up to this year!
 
             <span class="conclusion__byline">– Sacha and Raphaël</span>
+      t: |
+
+            <span class="first-letter">F</span>orget everything you know about CSS. Or at least, be ready to reconsider a lot of it. If like me you've been writing CSS for over a decade, CSS in 2020 looks nothing like what you were used to.
+
+            Instead of breakpoints, we can now leverage CSS Grid to make dynamic, responsive layouts that adapt to any viewport size with fewer lines of code. Instead of relying on global stylesheets, CSS-in-JS lets us colocate our styles with our components to build themeable design systems.
+
+            And most of all, Tailwind CSS has burst onto the scene and, through its use of utility-first CSS, forced us to reconsider the traditional dogma of semantic class names.
+
+            Whether all this change makes you want to write a hyped-up blog post or an angry Twitter rant, we are here to present the data, highlight the trends, and hopefully guide you through another eventful year of CSS!
+
+            ### Team
+
+            The State of CSS Survey is created and maintained by:
+
+            - [Sacha Greif](https://twitter.com/sachagreif): Design, writing, coding
+            - [Raphaël Benitte](https://twitter.com/benitteraphael): Data analysis, data visualizations
+
+            ### Download Our Data
+
+            You can [download the raw JSON data for this survey](https://www.kaggle.com/sachag/state-of-css). Let us know if you end up making your own data visualizations!
+
+            ### Other Links
+
+            - [State of CSS Homepage](https://stateofcss.com)
+            - [State of JS](https://stateofjs.com)
+
+            ### Thanks
+
+            Thanks to all the people who helped us design the survey, including [Chen Hui-Jing](http://chenhuijing.com/), [Philip Jägenstedt](https://blog.foolip.org/), [Adam Argyke](https://nerdy.dev/), [Ahmad Shadeed](https://www.ishadeed.com/), [Robert Flack](https://github.com/flackr), [Dominic Nguyen](https://www.chromatic.com/), [Fantasai](http://fantasai.inkedblade.net/), and [Kilian Valkhof](https://kilianvalkhof.com/).
+
+            Additional thanks to [Alexey Pyltsyn](https://github.com/lex111) for his help with translations.  
+
+            ### Credits & Stuff
+
+            The site is set in IBM Plex Mono. Questions? Feedback? [Get in touch!](mailto:hello@stateofjs.com)
+
+            And now, let's see what CSS has been up to this year!
+
+            <span class="conclusion__byline">– Sacha and Raphaël</span>
 
     ###########################################################################
     # Tshirt
     ###########################################################################
 
     - key: sections.tshirt.title
+      t: T-shirt
       t: T-shirt
 
     - key: sections.tshirt.description
@@ -61,8 +101,17 @@ translations:
           What makes this shirt truly special is that it's the only piece of clothing that also teaches you practical, real-world CSS techniques.
 
           So whether you're going to a conference, a job interview, or just work, this shirt will demonstrate your CSS mastery like no other garment can!
+      t: |
+          ## Support the survey and look good in the process!
+
+          A quick announcement before the survey results. Introducing our very own 🎈🎉👕 State of CSS T-shirt 👕🎉🎈!
+
+          What makes this shirt truly special is that it's the only piece of clothing that also teaches you practical, real-world CSS techniques.
+
+          So whether you're going to a conference, a job interview, or just work, this shirt will demonstrate your CSS mastery like no other garment can!
     
     - key: tshirt.about
+      t: About the T-shirt
       t: About the T-shirt
 
     - key: tshirt.description
@@ -71,11 +120,18 @@ translations:
 
           We use a high-quality, super-soft tri-blend shirt with a slim fit. 
           This shirt sizes small, so if you prefer a looser fit we recommend ordering one size up from what you usually wear (I'm wearing an M in the photos).
+      t: |
+          The shirt features the State of CSS logo along with snippets of the actual CSS code used to create each shape. Who knows, you might learn a thing or two!
+
+          We use a high-quality, super-soft tri-blend shirt with a slim fit. 
+          This shirt sizes small, so if you prefer a looser fit we recommend ordering one size up from what you usually wear (I'm wearing an M in the photos).
 
     - key: tshirt.getit
       t: Get It
+      t: Get It
 
     - key: tshirt.price
+      t: USD $24 + shipping
       t: USD $24 + shipping
 
     ###########################################################################
@@ -86,8 +142,14 @@ translations:
       t: |
           This year's survey reached **11,492** people in **102** countries. For the first time this year,
           we were able to translate the survey questions in multiple languages thanks to an awesome team of volunteers.
+      t: |
+          This year's survey reached **11,492** people in **102** countries. For the first time this year,
+          we were able to translate the survey questions in multiple languages thanks to an awesome team of volunteers.
 
     - key: sections.features.description
+      t: |
+          CSS has seen a surge of new features in recent years, so as you'd expect adoption is
+          lagging a bit behind as the community takes its time to absorb new properties.
       t: |
           CSS has seen a surge of new features in recent years, so as you'd expect adoption is
           lagging a bit behind as the community takes its time to absorb new properties.
@@ -95,8 +157,14 @@ translations:
     - key: sections.units_selectors.description
       t: |
           We're willing to bet you'll find a few things you didn't know about in this section!
+      t: |
+          We're willing to bet you'll find a few things you didn't know about in this section!
 
     - key: sections.technologies.description
+      t: |
+          The CSS ecosystem is going through a renewal of sorts, as older mainstays like Bootstrap 
+          now have to accomodate newer entrants like Tailwind CSS. To say nothing of the whole CSS-in-JS
+          movement which, while it has yet to cross over to the CSS mainstream, is nonetheless quite dynamic. 
       t: |
           The CSS ecosystem is going through a renewal of sorts, as older mainstays like Bootstrap 
           now have to accomodate newer entrants like Tailwind CSS. To say nothing of the whole CSS-in-JS
@@ -106,8 +174,15 @@ translations:
       t: |
           No big surprises here, but it's worth highlighting the appearance of development-focused browsers
           like Polypane and Sizzy, which go a step further than traditional devtools.
+      t: |
+          No big surprises here, but it's worth highlighting the appearance of development-focused browsers
+          like Polypane and Sizzy, which go a step further than traditional devtools.
 
     - key: sections.environments.description
+      t: |
+          One of CSS's core strengths is its ability to adapt to different environment, yet for a variety
+          of reasons media like print and email remain unexplored by a majority of CSS developers. Might they
+          turn out to be the next frontier of CSS…?
       t: |
           One of CSS's core strengths is its ability to adapt to different environment, yet for a variety
           of reasons media like print and email remain unexplored by a majority of CSS developers. Might they
@@ -118,8 +193,15 @@ translations:
           The “other answers” results in this section highlight the richness and diversity of the CSS community,
           and feature many outstanding blogs and podcasts which we are looking forward to officially adding
           to the survey next year!
+      t: |
+          The “other answers” results in this section highlight the richness and diversity of the CSS community,
+          and feature many outstanding blogs and podcasts which we are looking forward to officially adding
+          to the survey next year!
 
     - key: sections.opinions.description
+      t: |
+          These opinions paint a picture of a language getting more mature, but also more complex. And perhaps
+          –at least while we struggle to keep up with the pace of change– a little less enjoyable?
       t: |
           These opinions paint a picture of a language getting more mature, but also more complex. And perhaps
           –at least while we struggle to keep up with the pace of change– a little less enjoyable?
@@ -132,12 +214,25 @@ translations:
     - key: blocks.gender.note
       t: |
           If you're interested in learning more, we [wrote a blog post](https://dev.to/sachagreif/is-our-survey-biased-against-women-49oj) that addresses the survey's gender dynamics.
+      t: |
+          If you're interested in learning more, we [wrote a blog post](https://dev.to/sachagreif/is-our-survey-biased-against-women-49oj) that addresses the survey's gender dynamics.
 
     - key: blocks.currently_missing_from_css.note
       t: |
           You can explore the full dataset of answers to this question in [this side project](https://whatsmissingfromcss.com/).
+      t: |
+          You can explore the full dataset of answers to this question in [this side project](https://whatsmissingfromcss.com/).
 
     - key: blocks.source.note
+      t: >
+      
+        This chart aggregates a mix of referrers, URL parameters, and freeform answers. 
+
+        - State of JS: the [State of JS](https://stateofjs.com) mailing list.
+
+        - State of CSS: the State of CSS mailing list; also matches `email`, `by email`, etc.
+
+        - Work: matches `work`, `colleagues`, `coworkers`, etc.
       t: >
       
         This chart aggregates a mix of referrers, URL parameters, and freeform answers. 
@@ -154,17 +249,22 @@ translations:
 
     - key: award.feature_adoption_delta_award.comment
       t: With a **{value}** progression in 2020, this was the year CSS Grid crossed over from new technology to established tool.
+      t: With a **{value}** progression in 2020, this was the year CSS Grid crossed over from new technology to established tool.
 
     - key: award.tool_usage_delta_award.comment
+      t: No other tool comes even close to Tailwind CSS's dramatic **{value}** progression over the last year.
       t: No other tool comes even close to Tailwind CSS's dramatic **{value}** progression over the last year.
 
     - key: award.tool_satisfaction_award.comment
       t: PostCSS's **{value}** satisfaction ratio shows that you can't beat doing one thing really, really well.
+      t: PostCSS's **{value}** satisfaction ratio shows that you can't beat doing one thing really, really well.
 
     - key: award.tool_interest_award.comment
       t: With a **{value}** ratio, CSS Modules have generated the most interest among CSS developers this year.
+      t: With a **{value}** ratio, CSS Modules have generated the most interest among CSS developers this year.
 
     - key: award.most_write_ins_award.comment
+      t: Many questions also accepted write-in answers, and with **{value}** mentions PhpStorm was the most popular item overall.
       t: Many questions also accepted write-in answers, and with **{value}** mentions PhpStorm was the most popular item overall.
 
       
@@ -173,6 +273,18 @@ translations:
     ###########################################################################
 
     - key: sections.conclusion.description
+      t: |
+            If a JavaScript developer writes a line of CSS code, are they now a CSS developer?
+            
+            This programming *kōan* illustrates a clear trend in the web development world: as more and more CSS developers are tasked with learning JavaScript, so are JavaScript developers starting to realize there might be more to this whole CSS thing than just `font-weight: bold;`. 
+
+            So asking about “the State of CSS” is inherently a tricky proposition: depending on who you ask you might get completely different answers! And how do you know which one's right?
+
+            Here's another kōan for you: the right answer is that there *is* no right answer. Each of the many tools, methodologies, frameworks, and libraries featured here has its place in the vast front-end ecosystem. 
+
+            Building a complex React app? Styled Components is a great option. Designing a static landing page? You can't go wrong with Sass! And even though Bootstrap has lost some of its original hype factor, you can't beat it when it comes to sheer number of themes and plugins.
+
+            So while we keep an eye on the shiny new toys popping up on GitHub every week, let's not forget the tools, techniques, and most of all people who have carried the CSS torch up to now. We'll need everybody if we're to keep CSS moving forward into 2021 and beyond!
       t: |
             If a JavaScript developer writes a line of CSS code, are they now a CSS developer?
             

--- a/src/i18n/ja-JP/state_of_css_2020.yml
+++ b/src/i18n/ja-JP/state_of_css_2020.yml
@@ -6,45 +6,45 @@ translations:
 
     - key: sections.introduction.description
       t: |
-            <span class="first-letter">忘</span>れましょう、CSSについて知っているすべてを。忘れられなくても、多くのことを見直す準備はしておきましょう。あなたが私と同じく、10年以上CSSを書いているひとなら、2020年のCSSは私たちが慣れ親しんだものとまったくもって違うものに見えるでしょう。
+          <span class="first-letter">忘</span>れましょう、CSSについて知っているすべてを。忘れられなくても、多くのことを見直す準備はしておきましょう。あなたが私と同じく、10年以上CSSを書いているひとなら、2020年のCSSは私たちが慣れ親しんだものとまったくもって違うものに見えるでしょう。
 
-            ブレークポイントの代わりにCSS Gridを使えば、様々はビューポートの大きさに対応するレスポンシブなレイアウトを、ずっと短いコードで書けます。グローバルなスタイルシートではなく、CSS-in-JSを使ってコンポーネントとスタイルを同じ場所に置くと、テーマのカスタマイズをしやすいデザインシステムを実現できます。
+          ブレークポイントの代わりにCSS Gridを使えば、様々はビューポートの大きさに対応するレスポンシブなレイアウトを、ずっと短いコードで書けます。グローバルなスタイルシートではなく、CSS-in-JSを使ってコンポーネントとスタイルを同じ場所に置くと、テーマのカスタマイズをしやすいデザインシステムを実現できます。
 
-            ほとんどの人にとって、Tailwind CSSは突然現れたものだったでしょう。そのユーティリティファーストなCSSという思想により、セマンティックなクラス名をつけようというこれまでの教えを考え直させました。
+          ほとんどの人にとって、Tailwind CSSは突然現れたものだったでしょう。そのユーティリティファーストなCSSという思想により、セマンティックなクラス名をつけようというこれまでの教えを考え直させました。
 
-            これらの変化は、意気がったブログ記事や荒れたツイートを生み出してしまうかもしれません。このサイトの提供するデータや、トレンドのハイライトが、来年も慌ただしくなるであろうCSS界を進む手助けになることを祈っています。
+          これらの変化は、意気がったブログ記事や荒れたツイートを生み出してしまうかもしれません。このサイトの提供するデータや、トレンドのハイライトが、来年も慌ただしくなるであろうCSS界を進む手助けになることを祈っています。
 
-            ### チーム
+          ### チーム
 
-            State of CSSは、私たちが開発・管理しています。
+          State of CSSは、私たちが開発・管理しています。
 
-            - [Sacha Greif](https://twitter.com/sachagreif): デザイン、ライティング、コーディング
-            - [Raphaël Benitte](https://twitter.com/benitteraphael): データ分析、ビジュアリゼーション
+          - [Sacha Greif](https://twitter.com/sachagreif): デザイン、ライティング、コーディング
+          - [Raphaël Benitte](https://twitter.com/benitteraphael): データ分析、ビジュアリゼーション
 
-            ### データのダウンロード
+          ### データのダウンロード
 
-            [アンケートの回答データ（JSON）をダウンロードできます](https://www.kaggle.com/sachag/state-of-css)。何か新しいビジュアリゼーションをつくったら、ぜひ教えてください。
+          [アンケートの回答データ（JSON）をダウンロードできます](https://www.kaggle.com/sachag/state-of-css)。何か新しいビジュアリゼーションをつくったら、ぜひ教えてください。
 
-            ### そのほかのリンク
+          ### そのほかのリンク
 
-            - [State of CSSホームページ](https://stateofcss.com)
-            - [State of JS](https://stateofjs.com)
+          - [State of CSSホームページ](https://stateofcss.com)
+          - [State of JS](https://stateofjs.com)
 
-            ### Thanks
+          ### Thanks
 
-            アンケートの設計を手伝ってくれたみなさん、とくに[Chen Hui-Jing](http://chenhuijing.com/)、[Philip Jägenstedt](https://blog.foolip.org/)、[Adam Argyke](https://nerdy.dev/)、[Ahmad Shadeed](https://www.ishadeed.com/)、[Robert Flack](https://github.com/flackr)、[Dominic Nguyen](https://www.chromatic.com/)、[Fantasai](http://fantasai.inkedblade.net/)、[Kilian Valkhof](https://kilianvalkhof.com/)に感謝します。
+          アンケートの設計を手伝ってくれたみなさん、とくに[Chen Hui-Jing](http://chenhuijing.com/)、[Philip Jägenstedt](https://blog.foolip.org/)、[Adam Argyke](https://nerdy.dev/)、[Ahmad Shadeed](https://www.ishadeed.com/)、[Robert Flack](https://github.com/flackr)、[Dominic Nguyen](https://www.chromatic.com/)、[Fantasai](http://fantasai.inkedblade.net/)、[Kilian Valkhof](https://kilianvalkhof.com/)に感謝します。
 
-            翻訳について手伝ってくれた[Alexey Pyltsyn](https://github.com/lex111)にも感謝します。
+          翻訳について手伝ってくれた[Alexey Pyltsyn](https://github.com/lex111)にも感謝します。
 
-            ### Credits & Stuff
+          ### Credits & Stuff
 
-            このサイトで使われている書体はIBM Plex Monoです。
-            
-            質問やフィードバックがあればぜひ[教えてください！](mailto:hello@stateofjs.com)
+          このサイトで使われている書体はIBM Plex Monoです。
+          
+          質問やフィードバックがあればぜひ[教えてください！](mailto:hello@stateofjs.com)
 
-            では、2020年のCSSについて見てみましょう！
+          では、2020年のCSSについて見てみましょう！
 
-            <span class="conclusion__byline">– Sacha and Raphaël</span>
+          <span class="conclusion__byline">– Sacha and Raphaël</span>
 
     ###########################################################################
     # Tshirt
@@ -129,13 +129,13 @@ translations:
 
     - key: blocks.source.note
       t: |
-        このチャートはリファラー、URLパラメーター、自由回答を集計したものです。
+          このチャートはリファラー、URLパラメーター、自由回答を集計したものです。
 
-        - State of JS: [State of JS](https://stateofjs.com)のメーリングリストです
+          - State of JS: [State of JS](https://stateofjs.com)のメーリングリストです
 
-        - State of CSS: State of CSSのメーリングリストと、`email`, `by email`といった文言を含めています
+          - State of CSS: State of CSSのメーリングリストと、`email`, `by email`といった文言を含めています
 
-        - Work: `work`, `colleagues`, `coworkers`といった文言を集めたものです
+          - Work: `work`, `colleagues`, `coworkers`といった文言を集めたものです
 
     ###########################################################################
     # Awards
@@ -163,17 +163,17 @@ translations:
 
     - key: sections.conclusion.description
       t: |
-            JavaScript開発者がCSSを1行書いたら、もうそれでCSS開発者になったと言えるのでしょうか？
+          JavaScript開発者がCSSを1行書いたら、もうそれでCSS開発者になったと言えるのでしょうか？
 
-            この公案はウェブ開発の世界にある、いまのトレンドを表しています。CSS開発者がどんどんとJavaScriptを学ぶ必要にかられ、またJavaScript開発者も`font-weight: bold;`以外にもCSSがあることに気づき始めているのです。
+          この公案はウェブ開発の世界にある、いまのトレンドを表しています。CSS開発者がどんどんとJavaScriptを学ぶ必要にかられ、またJavaScript開発者も`font-weight: bold;`以外にもCSSがあることに気づき始めているのです。
 
-            こうなると「CSSの現状」を問うのは、とても難しくなります。相手が誰によるかで答えが変わってしまうからです！様々な答えの中から、どの答えが正しいとどうやって決められるのでしょうか？
+          こうなると「CSSの現状」を問うのは、とても難しくなります。相手が誰によるかで答えが変わってしまうからです！様々な答えの中から、どの答えが正しいとどうやって決められるのでしょうか？
 
-            ここでもうひとつの公案です。正しい答えは、そんなものなんてないということです。ここで取り上げた多くのツール、設計手法、フレームワーク、ライブラリ、それぞれがフロントエンドのエコシステムの一部を担っているのです。
+          ここでもうひとつの公案です。正しい答えは、そんなものなんてないということです。ここで取り上げた多くのツール、設計手法、フレームワーク、ライブラリ、それぞれがフロントエンドのエコシステムの一部を担っているのです。
 
-            複雑なReactアプリを作る？Styled Componentsはとてもいいものです。静的なランディングページを作る？Sassを使えばそう間違えは起こしません。一時期のハイプこそ収まってはいますが、テーマやプラグインの数においてBootstrapにかなうものはありません。
+          複雑なReactアプリを作る？Styled Componentsはとてもいいものです。静的なランディングページを作る？Sassを使えばそう間違えは起こしません。一時期のハイプこそ収まってはいますが、テーマやプラグインの数においてBootstrapにかなうものはありません。
 
-            このプロジェクトは今後も、GitHubに毎週のように現れる新しいプロジェクトを見続けますが、ツールやテクニック、そしてなによりCSSの灯りを守ってきた人々を忘れてはいけません。CSSを2021年、そして未来にむけて進めるには、みんなの力が必要なのです！
+          このプロジェクトは今後も、GitHubに毎週のように現れる新しいプロジェクトを見続けますが、ツールやテクニック、そしてなによりCSSの灯りを守ってきた人々を忘れてはいけません。CSSを2021年、そして未来にむけて進めるには、みんなの力が必要なのです！
 
     ###########################################################################
     # Picks


### PR DESCRIPTION
Yet complete (this lacks translation for My 2020 Picks), but I guess it's much better than showing English on selecting Japanese.