### PR TITLE
Label updates

### DIFF
--- a/src/i18n/en-US/common.yml
+++ b/src/i18n/en-US/common.yml
@@ -477,14 +477,6 @@ translations:
       t: Man
     - key: options.gender.non_binary
       t: Non-Binary
-    - key: options.gender.third_gender
-      t: Third Gender
-    - key: options.gender.two_spirit
-      t: Two-Spirit
-    - key: options.gender.genderqueer
-      t: Genderqueer
-    - key: options.gender.genderfluid
-      t: Genderfluid
     - key: options.gender.questioning
       t: Questioning
     - key: options.gender.not_listed
@@ -653,17 +645,18 @@ translations:
       t: How proficient are you at back-end development?
 
     # gender
-    # see https://www.alchemer.com/resources/blog/how-to-write-survey-gender-questions/
     - key: user_info.gender
       t: Gender
     - key: user_info.gender.description
-      t: What's your gender? Select all that apply. The survey is anonymous, and we only use this information to highlight which demographics responded to the survey. 
+      t: >
+        We use this data to help track and improve the survey's representativeness. 
 
     # skin tone/appearance
     - key: user_info.race_ethnicity
       t: Race & Ethnicity
     - key: user_info.race_ethnicity.description
-      t: The survey is anonymous, and we only use this information to highlight which demographics responded to the survey.
+      t: >
+        We use this data to help track and improve the survey's representativeness. 
 
     # other info
     - key: user_info.how_did_user_find_out_about_the_survey

--- a/src/i18n/en-US/common.yml
+++ b/src/i18n/en-US/common.yml
@@ -80,6 +80,14 @@ translations:
           Note: all questions are optional, reaching 100% completion is not required.
     - key: general.data_is_saved
       t: Your data is saved whenever you navigate to the previous or next section.
+    - key: general.close_nav
+      t: Close menu
+    - key: general.open_nav
+      t: Open menu
+    - key: general.more_actions
+      t: More actions
+    - key: general.skip_to_content
+      t: Skip to content
 
     # thanks
     - key: general.back

--- a/src/i18n/en-US/common.yml
+++ b/src/i18n/en-US/common.yml
@@ -472,6 +472,14 @@ translations:
       t: Man
     - key: options.gender.non_binary
       t: Non-Binary
+    - key: options.gender.third_gender
+      t: Third Gender
+    - key: options.gender.two_spirit
+      t: Two-Spirit
+    - key: options.gender.two_spirit
+      t: Genderqueer
+    - key: options.gender.two_spirit
+      t: Genderfluid
     - key: options.gender.questioning
       t: Questioning
     - key: options.gender.not_listed
@@ -638,7 +646,7 @@ translations:
     - key: user_info.gender
       t: Gender
     - key: user_info.gender.description
-      t: What's your gender? The survey is anonymous, and we only use this information to highlight which demographics responded to the survey. 
+      t: What's your gender? Select all that apply. The survey is anonymous, and we only use this information to highlight which demographics responded to the survey. 
 
     # skin tone/appearance
     - key: user_info.race_ethnicity

--- a/src/i18n/en-US/common.yml
+++ b/src/i18n/en-US/common.yml
@@ -476,9 +476,9 @@ translations:
       t: Third Gender
     - key: options.gender.two_spirit
       t: Two-Spirit
-    - key: options.gender.two_spirit
+    - key: options.gender.genderqueer
       t: Genderqueer
-    - key: options.gender.two_spirit
+    - key: options.gender.genderfluid
       t: Genderfluid
     - key: options.gender.questioning
       t: Questioning

--- a/src/i18n/en-US/common.yml
+++ b/src/i18n/en-US/common.yml
@@ -459,11 +459,15 @@ translations:
     # Gender
 
     - key: options.gender.female
-      t: Female
+      t: Woman
     - key: options.gender.male
-      t: Male
+      t: Man
     - key: options.gender.non_binary
-      t: Non-Binary/Third Gender
+      t: Non-Binary
+    - key: options.gender.questioning
+      t: Questioning
+    - key: options.gender.not_listed
+      t: Not Listed 
     - key: options.gender.prefer_not_to_say
       t: Prefer not to say
 
@@ -601,7 +605,7 @@ translations:
     - key: user_info.job_title
       t: Job Title
     - key: user_info.job_title.description
-      t: How do you introduce yourself at parties?
+      t: How do you introduce yourself to others?
 
     # javascript proficiency
     - key: user_info.javascript_proficiency
@@ -626,11 +630,13 @@ translations:
     - key: user_info.gender
       t: Gender
     - key: user_info.gender.description
-      t: To which gender identity do you most identify?
+      t: What's your gender? The survey is anonymous, and we only use this information to highlight which demographics responded to the survey. 
 
     # skin tone/appearance
     - key: user_info.race_ethnicity
       t: Race & Ethnicity
+    - key: user_info.race_ethnicity.description
+      t: The survey is anonymous, and we only use this information to highlight which demographics responded to the survey.
 
     # other info
     - key: user_info.how_did_user_find_out_about_the_survey

--- a/src/i18n/en-US/common.yml
+++ b/src/i18n/en-US/common.yml
@@ -490,11 +490,13 @@ translations:
     # Race & Ethnicity
 
     - key: options.race_ethnicity.white_european
-      t: White or of European descent
+      t: White
     - key: options.race_ethnicity.south_asian
       t: South Asian
+    - key: options.race_ethnicity.south_east_asian
+      t: South East Asian
     - key: options.race_ethnicity.hispanic_latin
-      t: Hispanic or Latino/Latina
+      t: Hispanic or Latino/Latina/Latinx
     - key: options.race_ethnicity.east_asian
       t: East Asian
     - key: options.race_ethnicity.middle_eastern
@@ -507,6 +509,10 @@ translations:
       t: Biracial
     - key: options.race_ethnicity.native_american_islander_australian
       t: Native American, Pacific Islander, or Indigenous Australian
+    - key: options.race_ethnicity.not_listed
+      t: Not listed
+    - key: options.race_ethnicity.prefer_not_to_say
+      t: Prefer not to say
 
     # Form Factors
     - key: options.form_factors.desktop

--- a/src/i18n/en-US/surveys.yml
+++ b/src/i18n/en-US/surveys.yml
@@ -6,3 +6,5 @@ translations:
 
     - key: general.no_preview_surveys
       t: No surveys to preview
+    - key: general.global_nav
+      t: Global

--- a/src/i18n/en-US/surveys.yml
+++ b/src/i18n/en-US/surveys.yml
@@ -8,3 +8,15 @@ translations:
       t: No surveys to preview
     - key: general.global_nav
       t: Global
+
+    ###########################################################################
+    # Demographics (About You/User Info)
+    ###########################################################################
+
+    - key: user_info.gender.question
+      t: >
+        Which of the following describe you, if any? Please check all that apply.
+
+    - key: user_info.race_ethnicity.question
+      t: >
+        Which of the following describe you, if any? Please check all that apply.


### PR DESCRIPTION
## TL;DR
This update includes (both for US English only):
- Text needed for accessibility updates (skip to content link, labelling the icon-only buttons correctly, etc).
- Updated wording around demographics.

This update focuses mainly on the gender-related questions. I see there were more open issues in the other repos mentioning the wording around the demographics (specifically discussions around the race & ethnicity section, and a potential new disability section), so anticipate there will be more changes needed later to those parts as well 😊 

## Biggest changes
**Gender**
- Changed: `Male`→`Man`
- Changed: `Female`→`Woman`
- Changed: `Non-Binary/Third Gender`→`Non-Binary`
- Added: `Third Gender`
- Added: `Two-Spirit`
- Added: `Genderqueer`
- Added: `Genderfluid`
- Added: `Questioning`
- Added: `Not Listed`

The survey should use checkboxes instead of radio buttons, and allow for a write-in option. More gender options could be added. If any get removed, I recommend keeping at least the following:
- Man
- Woman
- Non-Binary
- Not listed / Write-in
- Prefer not to say

This still includes a large amount of people in a respectful way, and has a write-in option for those who are not represented.

Also changed the way gender was asked for to: `What's your gender? Select all that apply. The survey is anonymous, and we only use this information to highlight which demographics responded to the survey.` (instead of "identify as").

The last part of the sentence could be altered, @SachaG maybe you can update it since you have a better overview than me over how the data is stored etc? 

**Race & Ethnicity**
- Changed: `White or of European descent`→`White`
- Changed: `Hispanic or Latino/Latina`→`Hispanic or Latino/Latina/Latinx`
- Added: `South East Asian`
- Added: `Not Listed` _(free text box)_
- Added: `Prefer not to say`

